### PR TITLE
Fix exception storing updated photos for camera.py.

### DIFF
--- a/custom_components/ha_strava/camera.py
+++ b/custom_components/ha_strava/camera.py
@@ -160,16 +160,15 @@ class UrlCam(Camera):
     def img_update_handler(self, event):
         """handle new urls of Strava images"""
 
+        # Append new images to the urls dict, keyed by a url hash.
         for img_url in event.data["img_urls"]:
             if self.is_url_valid(url=img_url["url"]):
                 self._urls[md5(img_url["url"].encode()).hexdigest()] = {**img_url}
 
-        self._urls = {
-            k: v
-            for (k, v) in sorted(
-                list(self._urls.items()), key=lambda k_v: k_v[1]["date"]
-            )
-        }[-self._max_images :]
+        # Ensure the urls dict is sorted by date and truncated to max # images.
+        self._urls = dict(
+                [url for url in sorted(self._urls.items(), key=lambda k_v:
+                                       k_v[1]["date"])][-self._max_images :])
 
         self._pickle_urls()
         return


### PR DESCRIPTION
The original code generated a dict, then tried to take a slice (supset) from the list; but dicts aren't sliceable.

Instead slice the input list before creating the dict.

```
Logger: homeassistant
Source: custom_components/ha_strava/camera.py:167
Integration: HA Strava 2.0
First occurred: September 10, 2022 at 7:50:10 PM (2 occurrences)
Last logged: September 10, 2022 at 7:50:10 PM

Error doing job: Future exception was never retrieved
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/ha_strava/camera.py", line 167, in img_update_handler
    self._urls = {
TypeError: unhashable type: 'slice'
```