### PR TITLE
Revert "Improve Sensor Availability & Values"

### DIFF
--- a/custom_components/ha_strava/camera.py
+++ b/custom_components/ha_strava/camera.py
@@ -62,9 +62,6 @@ class UrlCam(Camera):
     Image URLs are fetched from the strava API and the URLs come as payload of the strava data update event
     Up to 100 URLs are stored in the Camera object
     """
-    _attr_name = CONF_PHOTOS_ENTITY
-    _attr_should_poll = False
-    _attr_unique_id = CONF_PHOTOS_ENTITY
 
     def __init__(self, default_enabled=True):
         """Initialize Camera component."""
@@ -139,6 +136,19 @@ class UrlCam(Camera):
         if len(self._urls) == self._url_index:
             return self._default_url
         return self._urls[list(self._urls.keys())[self._url_index]]["url"]
+
+    @property
+    def unique_id(self):
+        return CONF_PHOTOS_ENTITY
+
+    @property
+    def name(self):
+        """Return the name of this camera."""
+        return CONF_PHOTOS_ENTITY
+
+    @property
+    def should_poll(self):
+        return False
 
     @property
     def extra_state_attributes(self):


### PR DESCRIPTION
Reverts craibo/ha_strava#28

``This error originated from a custom integration.

Logger: homeassistant.loader
Source: custom_components/ha_strava/sensor.py:93
Integration: HA Strava 2.0 (documentation, issues)
First occurred: 00:03:30 (1 occurrences)
Last logged: 00:03:30

Unexpected exception importing platform custom_components.ha_strava.sensor
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/loader.py", line 681, in get_platform
cache[full_name] = self._import_platform(platform_name)
File "/usr/src/homeassistant/homeassistant/loader.py", line 698, in _import_platform
return importlib.import_module(f"{self.pkg_path}.{platform_name}")
File "/usr/local/lib/python3.10/importlib/init.py", line 126, in import_module
return _bootstrap._gcd_import(name[level:], package, level)
File "", line 1050, in _gcd_import
File "", line 1027, in _find_and_load
File "", line 1006, in _find_and_load_unlocked
File "", line 688, in _load_unlocked
File "", line 883, in exec_module
File "", line 241, in _call_with_frames_removed
File "/config/custom_components/ha_strava/sensor.py", line 88, in
class StravaSummaryStatsSensor(SensorEntity):
File "/config/custom_components/ha_strava/sensor.py", line 93, in StravaSummaryStatsSensor
_attr_state_class = SensorStateClass.TOTAL
NameError: name 'SensorStateClass' is not defined`