### PR TITLE
Improve Sensor Availability & Values (revert-revert)

### DIFF
--- a/custom_components/ha_strava/camera.py
+++ b/custom_components/ha_strava/camera.py
@@ -62,6 +62,9 @@ class UrlCam(Camera):
     Image URLs are fetched from the strava API and the URLs come as payload of the strava data update event
     Up to 100 URLs are stored in the Camera object
     """
+    _attr_name = CONF_PHOTOS_ENTITY
+    _attr_should_poll = False
+    _attr_unique_id = CONF_PHOTOS_ENTITY
 
     def __init__(self, default_enabled=True):
         """Initialize Camera component."""
@@ -136,19 +139,6 @@ class UrlCam(Camera):
         if len(self._urls) == self._url_index:
             return self._default_url
         return self._urls[list(self._urls.keys())[self._url_index]]["url"]
-
-    @property
-    def unique_id(self):
-        return CONF_PHOTOS_ENTITY
-
-    @property
-    def name(self):
-        """Return the name of this camera."""
-        return CONF_PHOTOS_ENTITY
-
-    @property
-    def should_poll(self):
-        return False
 
     @property
     def extra_state_attributes(self):


### PR DESCRIPTION
+ Fixes missing import
+ Use SensorEntity for sensors, rather than the base Entity class.
+ Use instance and class variables for static sensor properties.
+ Use the availability property to avoid "-1" as entity states.