### PR TITLE
disable-scheduled-polling: Standardize Stats sensor names

### DIFF
--- a/custom_components/ha_strava/const.py
+++ b/custom_components/ha_strava/const.py
@@ -1,5 +1,7 @@
 """Constants for the Strava Home Assistant integration."""
 
+import re
+
 DOMAIN = "ha_strava"
 CONFIG_ENTRY_TITLE = "Strava"
 
@@ -410,7 +412,7 @@ def get_athlete_name_from_title(title: str) -> str:
     """Extract clean athlete name from config entry title."""
     if not title or not title.startswith("Strava:"):
         return "Unknown"
-    
+
     # Remove "Strava:" prefix and strip whitespace
     name = title.replace("Strava:", "").strip()
     return name if name else "Unknown"
@@ -431,7 +433,9 @@ def generate_sensor_id(athlete_id: str, activity_type: str, sensor_type: str) ->
     return f"strava_{athlete_id}_{activity_type}_{sensor_type}"
 
 
-def generate_sensor_name(athlete_name: str, activity_type: str, sensor_type: str) -> str:
+def generate_sensor_name(
+    athlete_name: str, activity_type: str, sensor_type: str
+) -> str:
     """Generate standardized sensor name."""
     # Format sensor type for display (replace underscores with spaces and title case)
     formatted_sensor = sensor_type.replace("_", " ").title()
@@ -445,4 +449,7 @@ def normalize_activity_type(activity_type: str) -> str:
 
 def format_activity_type_display(activity_type: str) -> str:
     """Format activity type for display in names."""
-    return activity_type.title()
+    # Handle camelCase by inserting spaces before uppercase letters (except the first one)
+    # Insert space before uppercase letters that follow lowercase letters
+    formatted = re.sub(r"(?<=[a-z])(?=[A-Z])", " ", activity_type)
+    return formatted

--- a/custom_components/ha_strava/sensor.py
+++ b/custom_components/ha_strava/sensor.py
@@ -51,13 +51,13 @@ from .const import (
     SUPPORTED_ACTIVITY_TYPES,
     UNIT_PACE_MINUTES_PER_KILOMETER,
     UNIT_PACE_MINUTES_PER_MILE,
-    get_athlete_name_from_title,
+    format_activity_type_display,
     generate_device_id,
     generate_device_name,
     generate_sensor_id,
     generate_sensor_name,
+    get_athlete_name_from_title,
     normalize_activity_type,
-    format_activity_type_display,
 )
 from .coordinator import StravaDataUpdateCoordinator
 
@@ -354,12 +354,12 @@ class StravaSummaryStatsSensor(CoordinatorEntity, SensorEntity):
             activity_type = parts[-2]
             period = parts[0]
             formatted_sensor = self._metric_key.replace("_", " ").title()
-            return f"Strava {self._athlete_name} {period.title()} {activity_type.title()} {formatted_sensor}"
+            return f"Strava {self._athlete_name} Stats {period.title()} {activity_type.title()} {formatted_sensor}"
         elif self._api_key in ["biggest_ride_distance", "biggest_climb_elevation_gain"]:
             formatted_sensor = self._metric_key.replace("_", " ").title()
-            return f"Strava {self._athlete_name} {formatted_sensor}"
+            return f"Strava {self._athlete_name} Stats {formatted_sensor}"
         else:
-            return f"Strava {self._athlete_name} {self._display_name}"
+            return f"Strava {self._athlete_name} Stats {self._display_name}"
 
     @property
     def extra_state_attributes(self):
@@ -423,9 +423,16 @@ class StravaActivityTypeSensor(CoordinatorEntity, SensorEntity):
         """Return device information."""
         return {
             "identifiers": {
-                (DOMAIN, generate_device_id(self._athlete_id, self._normalized_activity_type))
+                (
+                    DOMAIN,
+                    generate_device_id(
+                        self._athlete_id, self._normalized_activity_type
+                    ),
+                )
             },
-            "name": generate_device_name(self._athlete_name, format_activity_type_display(self._activity_type)),
+            "name": generate_device_name(
+                self._athlete_name, format_activity_type_display(self._activity_type)
+            ),
             "manufacturer": "Powered by Strava",
             "model": f"{self._activity_type} Activity",
             "configuration_url": f"{STRAVA_ACTHLETE_BASE_URL}{self._athlete_id}",
@@ -568,9 +575,16 @@ class StravaActivityAttributeSensor(CoordinatorEntity, SensorEntity):
         """Return device information."""
         return {
             "identifiers": {
-                (DOMAIN, generate_device_id(self._athlete_id, self._normalized_activity_type))
+                (
+                    DOMAIN,
+                    generate_device_id(
+                        self._athlete_id, self._normalized_activity_type
+                    ),
+                )
             },
-            "name": generate_device_name(self._athlete_name, format_activity_type_display(self._activity_type)),
+            "name": generate_device_name(
+                self._athlete_name, format_activity_type_display(self._activity_type)
+            ),
             "manufacturer": "Powered by Strava",
             "model": f"{self._activity_type} Activity",
             "configuration_url": f"{STRAVA_ACTHLETE_BASE_URL}{self._athlete_id}",
@@ -613,9 +627,9 @@ class StravaActivityAttributeSensor(CoordinatorEntity, SensorEntity):
     def name(self):
         """Return the name of the sensor."""
         return generate_sensor_name(
-            self._athlete_name, 
-            format_activity_type_display(self._activity_type), 
-            self._attribute_type
+            self._athlete_name,
+            format_activity_type_display(self._activity_type),
+            self._attribute_type,
         )
 
     def _is_metric(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,10 @@
 """Test configuration for ha_strava."""
 
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aioresponses import aioresponses
-from homeassistant import config_entries
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_entry_oauth2_flow
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ha_strava.const import (
@@ -42,7 +38,7 @@ def mock_config_entry():
         options={
             CONF_ACTIVITY_TYPES_TO_TRACK: ["Run", "Ride", "Walk", "Swim"],
         },
-        title="Test Strava User",
+        title="Strava: Test User",
     )
 
 
@@ -63,7 +59,7 @@ def mock_config_entry_all_activities():
                 "token_type": "Bearer",
             },
         },
-        title="Test Strava User",
+        title="Strava: Test User",
     )
 
 

--- a/tests/custom_components/ha_strava/test_activity_attribute_sensors.py
+++ b/tests/custom_components/ha_strava/test_activity_attribute_sensors.py
@@ -2,14 +2,7 @@
 
 from unittest.mock import MagicMock
 
-import pytest
-from homeassistant.components.sensor import SensorDeviceClass
-from homeassistant.const import UnitOfLength, UnitOfSpeed, UnitOfTime
-from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
 from custom_components.ha_strava.const import (
-    CONF_ACTIVITY_TYPES_TO_TRACK,
     CONF_ATTR_DEVICE_MANUFACTURER,
     CONF_ATTR_DEVICE_NAME,
     CONF_ATTR_DEVICE_TYPE,
@@ -31,7 +24,6 @@ from custom_components.ha_strava.const import (
     CONF_SENSOR_SPEED,
     CONF_SENSOR_TITLE,
     CONF_SENSOR_TROPHIES,
-    SUPPORTED_ACTIVITY_TYPES,
 )
 from custom_components.ha_strava.sensor import (
     StravaActivityAttributeSensor,
@@ -75,7 +67,7 @@ class TestStravaActivityAttributeSensor:
             "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
         }
         coordinator.entry = MagicMock()
-        coordinator.entry.title = "Test User"
+        coordinator.entry.title = "Strava: Test User"
 
         sensor = StravaActivityAttributeSensor(
             coordinator=coordinator,
@@ -85,9 +77,7 @@ class TestStravaActivityAttributeSensor:
         )
 
         device_info = sensor.device_info
-        assert device_info["identifiers"] == {
-            ("ha_strava", "strava_12345_run")
-        }
+        assert device_info["identifiers"] == {("ha_strava", "strava_12345_run")}
         assert device_info["name"] == "Strava Test User Run"
         assert device_info["manufacturer"] == "Powered by Strava"
         assert device_info["model"] == "Run Activity"
@@ -175,6 +165,7 @@ class TestStravaActivityAttributeSensor:
             "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
         }
         coordinator.entry = MagicMock()
+        coordinator.entry.title = "Strava: Test User"
 
         sensor = StravaActivityAttributeSensor(
             coordinator=coordinator,
@@ -183,7 +174,7 @@ class TestStravaActivityAttributeSensor:
             athlete_id="12345",
         )
 
-        assert sensor.name == "Strava Run Test Attribute"
+        assert sensor.name == "Strava Test User Run Test Attribute"
 
 
 class TestStravaActivityTitleSensor:

--- a/tests/custom_components/ha_strava/test_sensor.py
+++ b/tests/custom_components/ha_strava/test_sensor.py
@@ -234,6 +234,8 @@ class TestStravaSummaryStatsSensor:
             "activities": [],
             "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
         }
+        coordinator.entry = MagicMock()
+        coordinator.entry.title = "Strava: Test User"
 
         sensor = StravaSummaryStatsSensor(
             coordinator=coordinator,
@@ -243,7 +245,7 @@ class TestStravaSummaryStatsSensor:
             athlete_id="12345",
         )
 
-        assert sensor.name == "Strava Test User Recent Run Distance"
+        assert sensor.name == "Strava Test User Stats Recent Run Distance"
         assert sensor.unique_id == "strava_12345_stats_recent_run_totals_distance"
 
     def test_sensor_state_with_stats(self, mock_strava_stats):


### PR DESCRIPTION
- Update StravaSummaryStatsSensor name to include Stats
- Add camelCase display handling in format_activity_type_display
- Adjust activity type and attribute sensor tests to new naming
- Fix config entry titles to Strava: Test User in fixtures
- Align activity attributes keys and expectations in tests