### PR TITLE
fix: Remove deprecated config_entry assignment in OptionsFlow

### DIFF
--- a/custom_components/ha_strava/config_flow.py
+++ b/custom_components/ha_strava/config_flow.py
@@ -51,9 +51,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     Data Entry flow to allow runtime changes to the Strava Home Assistant Config
     """
 
-    def __init__(self, config_entry):
+    def __init__(self):
         """Initialize the options flow."""
-        self.config_entry = config_entry
         self._config_entry_title = None
         self._import_strava_images = None
         self._img_update_interval_seconds = None
@@ -297,4 +296,4 @@ class OAuth2FlowHandler(
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()


### PR DESCRIPTION
- Remove explicit self.config_entry assignment from OptionsFlowHandler.__init__
- Remove config_entry parameter from __init__ method
- Update async_get_options_flow to not pass config_entry parameter
- Use inherited config_entry property from OptionsFlow base class
- Fixes deprecation warning for Home Assistant 2025.12+ compatibility