### PR TITLE
sensor-display-name: Update Kcal sensor display name to Calories

### DIFF
--- a/custom_components/ha_strava/const.py
+++ b/custom_components/ha_strava/const.py
@@ -543,8 +543,13 @@ def generate_recent_activity_sensor_name(
     athlete_name: str, sensor_type: str, activity_index: int = 0
 ) -> str:
     """Generate standardized recent activity sensor name."""
-    # Format sensor type for display (replace underscores with spaces and title case)
-    formatted_sensor = sensor_type.replace("_", " ").title()
+    # Special case for calories sensor
+    if sensor_type == "kcal":
+        formatted_sensor = "Calories"
+    else:
+        # Format sensor type for display (replace underscores with spaces and title case)
+        formatted_sensor = sensor_type.replace("_", " ").title()
+
     if activity_index == 0:
         return f"Strava {athlete_name} Recent Activity {formatted_sensor}"
     return (

--- a/tests/custom_components/ha_strava/test_constants_multiple_activities.py
+++ b/tests/custom_components/ha_strava/test_constants_multiple_activities.py
@@ -286,6 +286,26 @@ class TestGenerateRecentActivitySensorName:
                 == f"Strava Test User Recent Activity 2 {expected_formatted}"
             )
 
+    def test_kcal_sensor_type_formatting(self):
+        """Test that 'kcal' sensor type is properly formatted as 'Calories'."""
+        athlete_name = "Test User"
+
+        # Test index 0 - should show "Calories" not "Kcal"
+        sensor_name = generate_recent_activity_sensor_name(athlete_name, "kcal", 0)
+        assert sensor_name == "Strava Test User Recent Activity Calories"
+
+        # Test index 1 - should show "Calories" not "Kcal"
+        sensor_name = generate_recent_activity_sensor_name(athlete_name, "kcal", 1)
+        assert sensor_name == "Strava Test User Recent Activity 2 Calories"
+
+        # Test index 2 - should show "Calories" not "Kcal"
+        sensor_name = generate_recent_activity_sensor_name(athlete_name, "kcal", 2)
+        assert sensor_name == "Strava Test User Recent Activity 3 Calories"
+
+        # Test index 9 (max) - should show "Calories" not "Kcal"
+        sensor_name = generate_recent_activity_sensor_name(athlete_name, "kcal", 9)
+        assert sensor_name == "Strava Test User Recent Activity 10 Calories"
+
     def test_different_athlete_names(self):
         """Test sensor name generation with different athlete names."""
         sensor_type = "test_sensor"


### PR DESCRIPTION
- Add special case handling for calories sensor in generate_sensor_name function
- Change display name from 'Kcal' to 'Calories' for better user experience
- Maintain backward compatibility with existing sensor functionality- Add special case handling for calories sensor in generate_sensor_name function
- Change display name from 'Kcal' to 'Calories' for better user experience
- Maintain backward compatibility with existing sensor functionality