### PR TITLE
coordinator: Fix filtered activity counter logic for gear data

### DIFF
--- a/custom_components/ha_strava/coordinator.py
+++ b/custom_components/ha_strava/coordinator.py
@@ -148,8 +148,9 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
         activities_needing_details = set()
         activities_by_type = {}
         athlete_id = None
+        filtered_activity_count = 0
 
-        for idx, activity in enumerate(activities_json):
+        for activity in activities_json:
             athlete_id = int(activity["athlete"]["id"])
             sport_type = activity.get("type")
 
@@ -158,14 +159,15 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
                 continue
 
             activity_id = activity["id"]
+            filtered_activity_count += 1
 
             # Track most recent per type
             if sport_type not in activities_by_type:
                 activities_by_type[sport_type] = activity_id
                 activities_needing_details.add(activity_id)
 
-            # Track first N recent activities
-            if idx < num_recent_activities:
+            # Track first N recent activities (by filtered count, not set size)
+            if filtered_activity_count <= num_recent_activities:
                 activities_needing_details.add(activity_id)
 
         _LOGGER.debug(f"Found most recent activities per type: {activities_by_type}")

--- a/tests/custom_components/ha_strava/test_coordinator.py
+++ b/tests/custom_components/ha_strava/test_coordinator.py
@@ -65,18 +65,20 @@ class TestStravaDataUpdateCoordinator:
         # Plus the first N recent activities (default is 1, so first activity gets detailed call)
         activity_types_seen = set()
         activities_needing_details = set()
+        filtered_activity_count = 0
 
         for idx, activity in enumerate(mock_strava_activities):
             activity_type = activity.get("type")
             activity_id = activity["id"]
+            filtered_activity_count += 1
 
             # Track most recent per type
             if activity_type not in activity_types_seen:
                 activity_types_seen.add(activity_type)
                 activities_needing_details.add(activity_id)
 
-            # Track first N recent activities (default is 1)
-            if idx < 1:  # CONF_NUM_RECENT_ACTIVITIES_DEFAULT = 1
+            # Track first N recent activities (default is 1) - by filtered count, not index
+            if filtered_activity_count <= 1:  # CONF_NUM_RECENT_ACTIVITIES_DEFAULT = 1
                 activities_needing_details.add(activity_id)
 
         # Mock detailed activity calls for activities that need them
@@ -137,21 +139,25 @@ class TestStravaDataUpdateCoordinator:
         # Plus the first N recent activities (default is 1, so first activity gets detailed call)
         activity_types_seen = set()
         activities_needing_details = set()
+        filtered_activity_count = 0
 
         for idx, activity in enumerate(mock_strava_activities_all_types):
             activity_type = activity.get("type")
             activity_id = activity["id"]
 
+            # Only count activities that match selected types
+            if activity_type not in ["Run", "Ride"]:
+                continue
+
+            filtered_activity_count += 1
+
             # Track most recent per selected type
-            if (
-                activity_type in ["Run", "Ride"]
-                and activity_type not in activity_types_seen
-            ):
+            if activity_type not in activity_types_seen:
                 activity_types_seen.add(activity_type)
                 activities_needing_details.add(activity_id)
 
-            # Track first N recent activities (default is 1)
-            if idx < 1:  # CONF_NUM_RECENT_ACTIVITIES_DEFAULT = 1
+            # Track first N recent activities (default is 1) - by filtered count, not index
+            if filtered_activity_count <= 1:  # CONF_NUM_RECENT_ACTIVITIES_DEFAULT = 1
                 activities_needing_details.add(activity_id)
 
         # Mock detailed activity calls for activities that need them
@@ -538,18 +544,20 @@ class TestStravaDataUpdateCoordinator:
         # Mock activity detail responses - for most recent activity of each type AND first N recent activities
         activity_types_seen = set()
         activities_needing_details = set()
+        filtered_activity_count = 0
 
         for idx, activity in enumerate(mock_strava_activities):
             activity_type = activity.get("type")
             activity_id = activity["id"]
+            filtered_activity_count += 1
 
             # Track most recent per type
             if activity_type not in activity_types_seen:
                 activity_types_seen.add(activity_type)
                 activities_needing_details.add(activity_id)
 
-            # Track first N recent activities (default is 1)
-            if idx < 1:  # CONF_NUM_RECENT_ACTIVITIES_DEFAULT = 1
+            # Track first N recent activities (default is 1) - by filtered count, not index
+            if filtered_activity_count <= 1:  # CONF_NUM_RECENT_ACTIVITIES_DEFAULT = 1
                 activities_needing_details.add(activity_id)
 
         # Mock detailed activity calls for activities that need them
@@ -765,18 +773,20 @@ class TestStravaDataUpdateCoordinator:
         # Mock activity detail responses - for most recent activity of each type AND first N recent activities
         activity_types_seen = set()
         activities_needing_details = set()
+        filtered_activity_count = 0
 
         for idx, activity in enumerate(malformed_activities):
             activity_type = activity.get("type")
             activity_id = activity["id"]
+            filtered_activity_count += 1
 
             # Track most recent per type
             if activity_type not in activity_types_seen:
                 activity_types_seen.add(activity_type)
                 activities_needing_details.add(activity_id)
 
-            # Track first N recent activities (default is 1)
-            if idx < 1:  # CONF_NUM_RECENT_ACTIVITIES_DEFAULT = 1
+            # Track first N recent activities (default is 1) - by filtered count, not index
+            if filtered_activity_count <= 1:  # CONF_NUM_RECENT_ACTIVITIES_DEFAULT = 1
                 activities_needing_details.add(activity_id)
 
         # Mock detailed activity calls for activities that need them


### PR DESCRIPTION
- Fix bug using set length instead of filtered activity count
- Track filtered activities separately to ensure first N get detailed data
- Update all test cases to match corrected logic
- Remove unused idx variable