### PR TITLE
refresh-button: Add refresh button to activity devices

### DIFF
--- a/custom_components/ha_strava/button.py
+++ b/custom_components/ha_strava/button.py
@@ -71,7 +71,7 @@ async def async_setup_entry(
         )
 
     if buttons:
-        await async_add_entities(buttons)
+        async_add_entities(buttons)
 
 
 class StravaActivityRefreshButton(CoordinatorEntity, ButtonEntity):

--- a/tests/custom_components/ha_strava/test_button.py
+++ b/tests/custom_components/ha_strava/test_button.py
@@ -41,7 +41,7 @@ async def test_button_setup_creates_buttons(
 
     entities: list = []
 
-    async def _async_add_entities(new_entities):
+    def _async_add_entities(new_entities):
         entities.extend(new_entities)
 
     await async_setup_entry(hass, mock_config_entry, _async_add_entities)


### PR DESCRIPTION
- Remove await since async_add_entities is synchronous in Home Assistant
- Update test to use synchronous callback function