### PR TITLE
fix: Limit activity sensor creation to configured number

### DIFF
--- a/custom_components/ha_strava/button.py
+++ b/custom_components/ha_strava/button.py
@@ -12,6 +12,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     CONF_ATTR_SPORT_TYPE,
+    CONF_NUM_RECENT_ACTIVITIES,
+    CONF_NUM_RECENT_ACTIVITIES_DEFAULT,
     CONF_SENSOR_ID,
     DOMAIN,
     generate_device_id,
@@ -39,6 +41,11 @@ async def async_setup_entry(
 
     activities = (coordinator.data or {}).get("activities") or []
 
+    # Get number of recent activities from config, default to 1
+    num_recent_activities = entry.options.get(
+        CONF_NUM_RECENT_ACTIVITIES, CONF_NUM_RECENT_ACTIVITIES_DEFAULT
+    )
+
     per_type_added: set[str] = set()
     for activity in activities:
         sport_type = activity.get(CONF_ATTR_SPORT_TYPE)
@@ -60,7 +67,8 @@ async def async_setup_entry(
             )
         )
 
-    for index, _ in enumerate(activities):
+    # Only create buttons for the configured number of recent activities
+    for index in range(num_recent_activities):
         buttons.append(
             StravaRecentActivityRefreshButton(
                 coordinator=coordinator,

--- a/custom_components/ha_strava/coordinator.py
+++ b/custom_components/ha_strava/coordinator.py
@@ -451,13 +451,24 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
         if not updated:
             new_activities.append(processed_activity)
 
+        # Get number of recent activities from config
+        num_recent_activities = self.entry.options.get(
+            CONF_NUM_RECENT_ACTIVITIES, CONF_NUM_RECENT_ACTIVITIES_DEFAULT
+        )
+
+        # Sort activities by date and limit to configured number
+        sorted_activities = sorted(
+            new_activities,
+            key=lambda activity: activity[CONF_SENSOR_DATE],
+            reverse=True,
+        )
+
+        # Limit to configured number of recent activities
+        limited_activities = sorted_activities[:num_recent_activities]
+
         new_data = {
             **current_data,
-            "activities": sorted(
-                new_activities,
-                key=lambda activity: activity[CONF_SENSOR_DATE],
-                reverse=True,
-            ),
+            "activities": limited_activities,
         }
 
         self.async_set_updated_data(new_data)

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.0.9"
+  "version": "4.0.10"
 }


### PR DESCRIPTION
- Fix button creation to respect num_recent_activities limit
- Limit coordinator activities list to configured number
- Remove excess recent activity sensors on config change
- Disable activity type sensors when deselected