### PR TITLE
feat: Add gear sensors for bikes and shoes tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ When configuring the Strava API, the **Authorization Callback Domain** must be s
 - Activity data in Home Assistant **auto-updates** whenever you add, modify, or delete activities on Strava
 - **Activity Type Selection**: Choose which of the 50 supported activity types to track
 - **Device Source Tracking**: Automatically detects and displays the device used for each activity
+- **Gear Sensors**: Track your bikes and shoes with distance and detailed information (brand, model, etc.)
 - **Multi-User Support**: Add multiple Strava accounts, each with their own unique Strava app credentials
 - **Webhook-First Architecture**: Uses Strava webhooks for real-time updates, respecting API rate limits
 - **Easy set-up**: only enter your Strava Client-ID and Client-Secret and you're ready to go
@@ -54,6 +55,12 @@ The Strava Home Assistant Integration creates **sensor entities** for each activ
 - **Recent** (last 4 weeks): Distance, activity count, and other metrics
 - **Year-to-Date**: Cumulative statistics for the current year
 - **All-Time**: Lifetime statistics for each activity type
+
+**Gear Sensors:**
+
+- **Gear Name**: Shows the name of each gear item (bike or shoe) with attributes including brand, model, and description
+- **Gear Distance**: Tracks the total distance for each gear item with proper unit conversion
+- Configure the number of gear sensors to display (1-20, default: 3)
 
 **Supported Activity Types:**
 The integration supports all 50 Strava activity types including Run, Ride, Walk, Swim, Hike, AlpineSki, BackcountrySki, Badminton, Canoeing, Crossfit, EBikeRide, Elliptical, Golf, GravelRide, Handcycle, HighIntensityIntervalTraining, IceSkate, InlineSkate, Kayaking, Kitesurf, MountainBikeRide, NordicSki, Pickleball, Pilates, Racquetball, RockClimbing, RollerSki, Rowing, Sail, Skateboard, Snowboard, Snowshoe, Soccer, Squash, StairStepper, StandUpPaddling, Surfing, TableTennis, Tennis, TrailRun, Velomobile, VirtualRide, VirtualRow, VirtualRun, WeightTraining, Wheelchair, Windsurf, Workout, and Yoga.
@@ -148,6 +155,23 @@ This setting is selectable during initial setup and can be changed later under `
 ### 3. Photo Updates
 
 You can enable or disable automatic photo updates for the camera entity. When enabled, the integration will fetch new photos from your activities and update the camera entity accordingly.
+
+### 4. Gear Sensors
+
+You can enable gear sensors to track your bikes and shoes from Strava. When enabled, the integration will:
+
+- Fetch your most recently used gear items (bikes and shoes combined)
+- Create a device for each gear item
+- Create two sensors per gear:
+  - **Gear Name**: Shows the gear name with attributes (id, brand_name, model_name, primary, description)
+  - **Gear Distance**: Shows the total distance for the gear with proper unit conversion
+
+**Configuration Options:**
+
+- **Enable Gear Sensors**: Checkbox to enable/disable gear sensors
+- **Number of Gear Sensors**: Slider to select how many gear items to track (1-20, default: 3)
+
+The gear items are sorted by distance (most used first), and the integration respects API rate limits by caching gear details.
 
 **_NOTES_**
 

--- a/custom_components/ha_strava/const.py
+++ b/custom_components/ha_strava/const.py
@@ -45,6 +45,11 @@ CONF_NUM_RECENT_ACTIVITIES = "num_recent_activities"
 CONF_NUM_RECENT_ACTIVITIES_DEFAULT = 1
 CONF_NUM_RECENT_ACTIVITIES_MAX = 10
 
+# Gear Sensor Configuration
+CONF_GEAR_ENABLED = "gear_enabled"
+CONF_NUM_GEAR_SENSORS = "num_gear_sensors"
+CONF_NUM_GEAR_SENSORS_DEFAULT = 3
+
 STRAVA_ACTIVITY_BASE_URL = "https://www.strava.com/activities/"
 STRAVA_ACTHLETE_BASE_URL = "https://www.strava.com/dashboard"
 
@@ -562,6 +567,29 @@ def generate_recent_activity_sensor_name(
     return (
         f"Strava {athlete_name} Recent Activity {activity_index + 1} {formatted_sensor}"
     )
+
+
+def generate_gear_device_id(athlete_id: str, gear_index: int) -> str:
+    """Generate standardized gear device ID."""
+    return f"strava_{athlete_id}_gear_{gear_index}"
+
+
+def generate_gear_device_name(athlete_name: str, gear_name: str) -> str:
+    """Generate standardized gear device name."""
+    return f"Strava {athlete_name} {gear_name}"
+
+
+def generate_gear_sensor_id(athlete_id: str, gear_index: int, sensor_type: str) -> str:
+    """Generate standardized gear sensor ID."""
+    return f"strava_{athlete_id}_gear_{gear_index}_{sensor_type}"
+
+
+def generate_gear_sensor_name(
+    athlete_name: str, gear_name: str, sensor_type: str
+) -> str:
+    """Generate standardized gear sensor name."""
+    formatted_sensor = sensor_type.replace("_", " ").title()
+    return f"Strava {athlete_name} {gear_name} {formatted_sensor}"
 
 
 def normalize_activity_type(activity_type: str) -> str:

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.0.10"
+  "version": "4.1.0"
 }

--- a/custom_components/ha_strava/translations/en.json
+++ b/custom_components/ha_strava/translations/en.json
@@ -19,7 +19,9 @@
           "conf_photos": "Import Photos from Strava?",
           "conf_distance_unit": "Distance unit system to use",
           "activity_types_to_track": "Activity Types to Track",
-          "num_recent_activities": "Number of Recent Activities"
+          "num_recent_activities": "Number of Recent Activities",
+          "gear_enabled": "Enable Gear Sensors",
+          "num_gear_sensors": "Number of Gear Sensors"
         }
       }
     }
@@ -34,7 +36,9 @@
           "img_update_interval_seconds": "Image rotation (seconds)",
           "conf_photos": "Import Photos from Strava?",
           "conf_distance_unit": "Distance unit system to use",
-          "num_recent_activities": "Number of Recent Activities"
+          "num_recent_activities": "Number of Recent Activities",
+          "gear_enabled": "Enable Gear Sensors",
+          "num_gear_sensors": "Number of Gear Sensors"
         }
       }
     },

--- a/info.md
+++ b/info.md
@@ -26,6 +26,7 @@ When configuring the Strava API, the **Authorization Callback Domain** must be s
 - Activity data in Home Assistant **auto-updates** whenever you add, modify, or delete activities on Strava
 - **Activity Type Selection**: Choose which of the 50 supported activity types to track
 - **Device Source Tracking**: Automatically detects and displays the device used for each activity
+- **Gear Sensors**: Track your bikes and shoes with distance and detailed information (brand, model, etc.)
 - **Multi-User Support**: Add multiple Strava accounts, each with their own unique Strava app credentials
 - **Easy set-up**: only enter your Strava Client-ID and Client-Secret and you're ready to go
 
@@ -44,6 +45,12 @@ The Strava Home Assistant Integration creates **sensor entities** for each activ
 - **Recent** (last 4 weeks): Distance, activity count, and other metrics
 - **Year-to-Date**: Cumulative statistics for the current year
 - **All-Time**: Lifetime statistics for each activity type
+
+**Gear Sensors:**
+
+- **Gear Name**: Shows the name of each gear item (bike or shoe) with attributes including brand, model, and description
+- **Gear Distance**: Tracks the total distance for each gear item with proper unit conversion
+- Configure the number of gear sensors to display (1-20, default: 3)
 
 **Supported Activity Types:**
 The integration supports all 50 Strava activity types including Run, Ride, Walk, Swim, Hike, AlpineSki, BackcountrySki, Badminton, Canoeing, Crossfit, EBikeRide, Elliptical, Golf, GravelRide, Handcycle, HighIntensityIntervalTraining, IceSkate, InlineSkate, Kayaking, Kitesurf, MountainBikeRide, NordicSki, Pickleball, Pilates, Racquetball, RockClimbing, RollerSki, Rowing, Sail, Skateboard, Snowboard, Snowshoe, Soccer, Squash, StairStepper, StandUpPaddling, Surfing, TableTennis, Tennis, TrailRun, Velomobile, VirtualRide, VirtualRow, VirtualRun, WeightTraining, Wheelchair, Windsurf, Workout, and Yoga.
@@ -145,6 +152,23 @@ This setting is selectable on configuration of the Strava integration and from t
 ### 3. Photo Import Settings
 
 You can configure whether to import photos from your Strava activities and set the rotation interval for the camera entity.
+
+### 4. Gear Sensors
+
+You can enable gear sensors to track your bikes and shoes from Strava. When enabled, the integration will:
+
+- Fetch your most recently used gear items (bikes and shoes combined)
+- Create a device for each gear item
+- Create two sensors per gear:
+  - **Gear Name**: Shows the gear name with attributes (id, brand_name, model_name, primary, description)
+  - **Gear Distance**: Shows the total distance for the gear with proper unit conversion
+
+**Configuration Options:**
+
+- **Enable Gear Sensors**: Checkbox to enable/disable gear sensors
+- **Number of Gear Sensors**: Slider to select how many gear items to track (1-20, default: 3)
+
+The gear items are sorted by distance (most used first), and the integration respects API rate limits by caching gear details.
 
 **_NOTES_**
 


### PR DESCRIPTION
- Add gear sensor configuration options (enable/disable, count 1-20)
- Implement gear data fetching from Strava API with rate limit handling
- Create gear name and distance sensors with proper unit conversion
- Update documentation and bump version to 4.1.0