### PR TITLE
feat: Add gear sensors for bikes and shoes tracking

### DIFF
--- a/custom_components/ha_strava/config_flow.py
+++ b/custom_components/ha_strava/config_flow.py
@@ -533,7 +533,7 @@ class OAuth2FlowHandler(
     def extra_authorize_data(self) -> dict:
         """Extra data that needs to be appended to the authorize url."""
         return {
-            "scope": "activity:read_all",
+            "scope": "activity:read_all,profile:read_all",
             "approval_prompt": "force",
             "response_type": "code",
         }


### PR DESCRIPTION
- Update OAuth2 scopes to include profile:read_all to allow fetching gear (bikes/shoes)

- Detect insufficient permissions during gear fetch and trigger re-authentication