### PR TITLE
fix: Use sport_type for MTB/activity filtering and storage (Issue #293)

### DIFF
--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.1.3"
+  "version": "4.1.4"
 }

--- a/tests/custom_components/ha_strava/test_activity_type_sensors.py
+++ b/tests/custom_components/ha_strava/test_activity_type_sensors.py
@@ -241,6 +241,39 @@ class TestStravaActivityTypeSensor:
         assert attributes[CONF_ATTR_ACTIVITY_ID] == str(ride_activity[CONF_SENSOR_ID])
         assert attributes[CONF_ATTR_SPORT_TYPE] == ride_activity[CONF_ATTR_SPORT_TYPE]
 
+    def test_mountain_bike_ride_sensor_available_with_sport_type(self):
+        """Test MountainBikeRide activity-type sensor is available when data has sport_type MountainBikeRide."""
+        from custom_components.ha_strava.const import (
+            CONF_ATTR_SPORT_TYPE,
+            CONF_SENSOR_ID,
+            CONF_SENSOR_TITLE,
+        )
+
+        processed_activities = [
+            {
+                CONF_SENSOR_ID: 42,
+                CONF_SENSOR_TITLE: "Trail MTB Loop",
+                CONF_ATTR_SPORT_TYPE: "MountainBikeRide",
+            }
+        ]
+        coordinator = MagicMock()
+        coordinator.data = {
+            "activities": processed_activities,
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+        coordinator.entry = MagicMock()
+        coordinator.entry.title = "Strava: Test User"
+
+        sensor = StravaActivityTypeSensor(
+            coordinator=coordinator,
+            activity_type="MountainBikeRide",
+            athlete_id="12345",
+        )
+
+        assert sensor.available is True
+        assert sensor.native_value == "Trail MTB Loop"
+        assert sensor.extra_state_attributes[CONF_ATTR_SPORT_TYPE] == "MountainBikeRide"
+
     def test_sensor_attributes_swimming_specific_metrics(self, mock_strava_activities):
         """Test sensor attributes for swimming activities with specific metrics."""
         # Setup - use processed data from coordinator


### PR DESCRIPTION
- Filter activities by sport_type with fallback to type in coordinator
- Store CONF_ATTR_SPORT_TYPE from detail when available in _sensor_activity
- Add coordinator test for MountainBikeRide list/detail sport_type
- Add sensor test for MountainBikeRide availability with sport_type