### PR TITLE
fix: use stable gear ID for gear sensor unique_id (Issue #301)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ __pycache__/
 
 # Code assistants
 GEMINI.md
-CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Setup
+
+```bash
+# Create virtualenv and install all dependencies
+bash tools/setup_virtualenv.sh
+
+# Or manually:
+pip install -r requirements_dev.txt
+pip install -r requirements_test.txt
+pre-commit install
+```
+
+## Commands
+
+```bash
+# Run all tests
+python -m pytest
+
+# Run a single test file
+pytest tests/custom_components/ha_strava/test_coordinator.py -v
+
+# Run a specific test
+pytest tests/custom_components/ha_strava/test_sensor.py::test_name -v
+
+# Linting (also runs via pre-commit)
+black custom_components/ tests/
+isort custom_components/ tests/
+flake8 custom_components/ tests/
+pylint custom_components/ha_strava/
+```
+
+## Architecture
+
+This is a Home Assistant custom component integrating Strava athlete data. One config entry per Strava athlete (multi-user supported). `iot_class: cloud_push` — webhook-driven, not polled.
+
+**Entry point flow:**
+
+1. `async_setup_entry()` in `__init__.py` — sets up coordinator, registers `StravaWebhookView` at `/api/strava/webhook`, loads platforms (sensor, camera, button)
+2. `StravaDataUpdateCoordinator` (`coordinator.py`) — fetches activities, stats, gear, and photos via OAuth2 session; updates are triggered by webhooks, not a polling loop
+3. Webhook POST routes incoming events by `owner_id` to the correct coordinator (enabling multi-user)
+
+**Key modules:**
+
+| File             | Role                                                                               |
+| ---------------- | ---------------------------------------------------------------------------------- |
+| `__init__.py`    | Setup/teardown, webhook endpoint, webhook subscription                             |
+| `config_flow.py` | OAuth2 auth flow + options flow (activity types, gear, photos, units)              |
+| `coordinator.py` | Strava API calls, data caching, exponential backoff                                |
+| `sensor.py`      | All sensor entities: per-activity-type metrics, recent activities, summaries, gear |
+| `camera.py`      | Photo carousel (up to 30 images, 24h cache)                                        |
+| `button.py`      | Manual refresh buttons per activity type                                           |
+| `const.py`       | All constants: OAuth URLs, 50+ activity types, config keys, sensor attributes      |
+
+**Multi-user:**
+Each Strava account requires its own Strava API app (Strava limits one athlete per app). `unique_id` for each config entry = athlete ID. Webhook handler matches `owner_id` to route to the correct entry's coordinator.
+
+**OAuth2:**
+Uses `config_entry_oauth2_flow.OAuth2Session` with `LocalOAuth2Implementation`. Authorization callback domain must be `my.home-assistant.io`.
+
+**Webhook lifecycle:**
+`renew_webhook_subscription()` in `__init__.py` calls Strava's webhook API to (re)register. Subscription ID persists in the config entry. On unload, the subscription is deleted.
+
+## Code Standards
+
+- Max line length: 120 characters (Black, flake8, pylint all configured to this)
+- Type hints required on all functions
+- Pre-commit hooks enforce black, isort, flake8, pylint — run `pre-commit run --all-files` to check
+
+## Testing Patterns
+
+Tests use `pytest-homeassistant-custom-component`. Fixtures live in `tests/custom_components/ha_strava/conftest.py` — it provides `mock_config_entry`, `mock_strava_activities`, `mock_oauth_flow`, and other standard fixtures.
+
+```python
+async def test_example(hass, mock_config_entry):
+    # Use hass fixture from pytest-homeassistant-custom-component
+    ...
+```
+
+`asyncio_mode = auto` is set in `pytest.ini`, so async tests don't need `@pytest.mark.asyncio`.
+
+## Strava API Constraints
+
+- Rate limits: 100 requests/15 min, 1000 requests/day — coordinator caches aggressively and retries with exponential backoff (max 3 attempts)
+- Activities endpoint returns max 200 per call
+- Photos cached for 24 hours

--- a/custom_components/ha_strava/const.py
+++ b/custom_components/ha_strava/const.py
@@ -581,9 +581,9 @@ def generate_recent_activity_sensor_name(
     )
 
 
-def generate_gear_device_id(athlete_id: str, gear_index: int) -> str:
+def generate_gear_device_id(athlete_id: str, gear_id: str) -> str:
     """Generate standardized gear device ID."""
-    return f"strava_{athlete_id}_gear_{gear_index}"
+    return f"strava_{athlete_id}_gear_{gear_id}"
 
 
 def generate_gear_device_name(athlete_name: str, gear_name: str) -> str:
@@ -591,9 +591,9 @@ def generate_gear_device_name(athlete_name: str, gear_name: str) -> str:
     return f"Strava {athlete_name} {gear_name}"
 
 
-def generate_gear_sensor_id(athlete_id: str, gear_index: int, sensor_type: str) -> str:
+def generate_gear_sensor_id(athlete_id: str, gear_id: str, sensor_type: str) -> str:
     """Generate standardized gear sensor ID."""
-    return f"strava_{athlete_id}_gear_{gear_index}_{sensor_type}"
+    return f"strava_{athlete_id}_gear_{gear_id}_{sensor_type}"
 
 
 def generate_gear_sensor_name(

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.1.5"
+  "version": "4.1.6"
 }

--- a/custom_components/ha_strava/sensor.py
+++ b/custom_components/ha_strava/sensor.py
@@ -280,18 +280,21 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     # Create gear sensors if enabled
     if gear_enabled:
         gear_data = coordinator.data.get("gear") if coordinator.data else []
-        for gear_index, _gear_item in enumerate(gear_data):
+        for gear_item in gear_data:
+            gear_id = str(gear_item.get("id", ""))
+            if not gear_id:
+                continue
             entries.append(
                 StravaGearNameSensor(
                     coordinator,
-                    gear_index=gear_index,
+                    gear_id=gear_id,
                     athlete_id=athlete_id,
                 )
             )
             entries.append(
                 StravaGearDistanceSensor(
                     coordinator,
-                    gear_index=gear_index,
+                    gear_id=gear_id,
                     athlete_id=athlete_id,
                 )
             )
@@ -1715,28 +1718,28 @@ class StravaGearNameSensor(CoordinatorEntity, SensorEntity):
     def __init__(
         self,
         coordinator: StravaDataUpdateCoordinator,
-        gear_index: int,
+        gear_id: str,
         athlete_id: str,
     ):
         """Initialize the sensor."""
         super().__init__(coordinator)
-        self._gear_index = gear_index
+        self._gear_id = gear_id
         self._athlete_id = athlete_id
         self._athlete_name = get_athlete_name_from_title(self.coordinator.entry.title)
-        self._attr_unique_id = generate_gear_sensor_id(athlete_id, gear_index, "name")
+        self._attr_unique_id = generate_gear_sensor_id(athlete_id, gear_id, "name")
 
     @property
     def device_info(self):
         """Return device information."""
         gear_data = self._gear_data
         gear_name = (
-            gear_data.get("name", f"Gear {self._gear_index + 1}")
+            gear_data.get("name", f"Gear {self._gear_id}")
             if gear_data
-            else f"Gear {self._gear_index + 1}"
+            else f"Gear {self._gear_id}"
         )
         return {
             "identifiers": {
-                (DOMAIN, generate_gear_device_id(self._athlete_id, self._gear_index))
+                (DOMAIN, generate_gear_device_id(self._athlete_id, self._gear_id))
             },
             "name": generate_gear_device_name(self._athlete_name, gear_name),
             "manufacturer": "Powered by Strava",
@@ -1749,9 +1752,9 @@ class StravaGearNameSensor(CoordinatorEntity, SensorEntity):
         """Get the gear data for this sensor."""
         if not self.coordinator.data or not self.coordinator.data.get("gear"):
             return None
-        gear_list = self.coordinator.data["gear"]
-        if self._gear_index < len(gear_list):
-            return gear_list[self._gear_index]
+        for gear_item in self.coordinator.data["gear"]:
+            if str(gear_item.get("id", "")) == self._gear_id:
+                return gear_item
         return None
 
     @property
@@ -1770,16 +1773,16 @@ class StravaGearNameSensor(CoordinatorEntity, SensorEntity):
         if not self.available:
             return None
         gear_data = self._gear_data
-        return gear_data.get("name", f"Gear {self._gear_index + 1}")
+        return gear_data.get("name", f"Gear {self._gear_id}")
 
     @property
     def name(self):
         """Return the name of the sensor."""
         gear_data = self._gear_data
         gear_name = (
-            gear_data.get("name", f"Gear {self._gear_index + 1}")
+            gear_data.get("name", f"Gear {self._gear_id}")
             if gear_data
-            else f"Gear {self._gear_index + 1}"
+            else f"Gear {self._gear_id}"
         )
         return generate_gear_sensor_name(self._athlete_name, gear_name, "name")
 
@@ -1812,30 +1815,28 @@ class StravaGearDistanceSensor(CoordinatorEntity, SensorEntity):
     def __init__(
         self,
         coordinator: StravaDataUpdateCoordinator,
-        gear_index: int,
+        gear_id: str,
         athlete_id: str,
     ):
         """Initialize the sensor."""
         super().__init__(coordinator)
-        self._gear_index = gear_index
+        self._gear_id = gear_id
         self._athlete_id = athlete_id
         self._athlete_name = get_athlete_name_from_title(self.coordinator.entry.title)
-        self._attr_unique_id = generate_gear_sensor_id(
-            athlete_id, gear_index, "distance"
-        )
+        self._attr_unique_id = generate_gear_sensor_id(athlete_id, gear_id, "distance")
 
     @property
     def device_info(self):
         """Return device information."""
         gear_data = self._gear_data
         gear_name = (
-            gear_data.get("name", f"Gear {self._gear_index + 1}")
+            gear_data.get("name", f"Gear {self._gear_id}")
             if gear_data
-            else f"Gear {self._gear_index + 1}"
+            else f"Gear {self._gear_id}"
         )
         return {
             "identifiers": {
-                (DOMAIN, generate_gear_device_id(self._athlete_id, self._gear_index))
+                (DOMAIN, generate_gear_device_id(self._athlete_id, self._gear_id))
             },
             "name": generate_gear_device_name(self._athlete_name, gear_name),
             "manufacturer": "Powered by Strava",
@@ -1848,9 +1849,9 @@ class StravaGearDistanceSensor(CoordinatorEntity, SensorEntity):
         """Get the gear data for this sensor."""
         if not self.coordinator.data or not self.coordinator.data.get("gear"):
             return None
-        gear_list = self.coordinator.data["gear"]
-        if self._gear_index < len(gear_list):
-            return gear_list[self._gear_index]
+        for gear_item in self.coordinator.data["gear"]:
+            if str(gear_item.get("id", "")) == self._gear_id:
+                return gear_item
         return None
 
     @property
@@ -1895,9 +1896,9 @@ class StravaGearDistanceSensor(CoordinatorEntity, SensorEntity):
         """Return the name of the sensor."""
         gear_data = self._gear_data
         gear_name = (
-            gear_data.get("name", f"Gear {self._gear_index + 1}")
+            gear_data.get("name", f"Gear {self._gear_id}")
             if gear_data
-            else f"Gear {self._gear_index + 1}"
+            else f"Gear {self._gear_id}"
         )
         return generate_gear_sensor_name(self._athlete_name, gear_name, "distance")
 

--- a/tests/custom_components/ha_strava/test_gear_sensors.py
+++ b/tests/custom_components/ha_strava/test_gear_sensors.py
@@ -1,0 +1,216 @@
+"""Test gear sensors for ha_strava."""
+
+from unittest.mock import MagicMock
+
+from custom_components.ha_strava.const import (
+    CONF_DISTANCE_UNIT_OVERRIDE,
+    CONF_DISTANCE_UNIT_OVERRIDE_METRIC,
+    DOMAIN,
+)
+from custom_components.ha_strava.sensor import (
+    StravaGearDistanceSensor,
+    StravaGearNameSensor,
+)
+
+
+def _make_coordinator(gear_list, entry=None):
+    """Return a mock coordinator with the given gear list."""
+    coordinator = MagicMock()
+    coordinator.data = {"gear": gear_list}
+    if entry is None:
+        entry = MagicMock()
+        entry.title = "Strava: Test User"
+        entry.options = {}
+        entry.data = {}
+    coordinator.entry = entry
+    return coordinator
+
+
+GEAR_BIKE = {
+    "id": "b111111",
+    "name": "CGR SL",
+    "distance": 8000000.0,
+    "brand_name": "Genesis",
+    "model_name": "CGR SL",
+    "primary": True,
+    "description": "Gravel bike",
+}
+
+GEAR_SHOES = {
+    "id": "g222222",
+    "name": "Running Shoes",
+    "distance": 3000000.0,
+    "brand_name": "Nike",
+    "model_name": "Pegasus",
+    "primary": False,
+    "description": "",
+}
+
+GEAR_TRAINER = {
+    "id": "b333333",
+    "name": "Indoor Trainer",
+    "distance": 1000000.0,
+    "brand_name": "Wahoo",
+    "model_name": "KICKR",
+    "primary": False,
+    "description": "Smart trainer",
+}
+
+
+class TestStravaGearNameSensor:
+    """Tests for StravaGearNameSensor."""
+
+    def test_unique_id_uses_gear_id_not_index(self):
+        """unique_id must be stable and based on the Strava gear ID."""
+        coordinator = _make_coordinator([GEAR_BIKE, GEAR_SHOES])
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor.unique_id == "strava_12345_gear_b111111_name"
+
+    def test_unique_id_is_independent_of_list_position(self):
+        """Two sensors for different gear must have different unique_ids regardless of order."""
+        coordinator = _make_coordinator([GEAR_SHOES, GEAR_BIKE])
+        s1 = StravaGearNameSensor(coordinator, gear_id="b111111", athlete_id="12345")
+        s2 = StravaGearNameSensor(coordinator, gear_id="g222222", athlete_id="12345")
+        assert s1.unique_id != s2.unique_id
+        assert s1.unique_id == "strava_12345_gear_b111111_name"
+        assert s2.unique_id == "strava_12345_gear_g222222_name"
+
+    def test_gear_data_lookup_by_id(self):
+        """_gear_data returns the correct item regardless of its position in the list."""
+        # GEAR_SHOES is at index 0, GEAR_BIKE at index 1 (reversed order)
+        coordinator = _make_coordinator([GEAR_SHOES, GEAR_BIKE])
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor._gear_data == GEAR_BIKE
+
+    def test_native_value_after_reorder(self):
+        """native_value returns the correct gear name even after the list is reordered."""
+        # Initially: GEAR_BIKE first
+        coordinator = _make_coordinator([GEAR_BIKE, GEAR_SHOES])
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor.native_value == "CGR SL"
+
+        # Simulate reorder: GEAR_SHOES now first (e.g. distance changed)
+        coordinator.data = {"gear": [GEAR_SHOES, GEAR_TRAINER, GEAR_BIKE]}
+        assert sensor.native_value == "CGR SL"
+
+    def test_sensor_unavailable_when_gear_id_missing(self):
+        """Sensor is unavailable when its gear ID is no longer in the list."""
+        coordinator = _make_coordinator([GEAR_SHOES])
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor.available is False
+        assert sensor.native_value is None
+
+    def test_name_property(self):
+        """name property returns a human-readable name using gear's own name."""
+        coordinator = _make_coordinator([GEAR_BIKE])
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor.name == "Strava Test User CGR SL Name"
+
+    def test_device_info_uses_gear_id(self):
+        """device_info identifiers must be based on gear ID, not index."""
+        coordinator = _make_coordinator([GEAR_BIKE])
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        identifiers = sensor.device_info["identifiers"]
+        assert (DOMAIN, "strava_12345_gear_b111111") in identifiers
+
+    def test_extra_state_attributes(self):
+        """extra_state_attributes exposes gear metadata."""
+        coordinator = _make_coordinator([GEAR_BIKE])
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["id"] == "b111111"
+        assert attrs["brand_name"] == "Genesis"
+        assert attrs["model_name"] == "CGR SL"
+        assert attrs["primary"] is True
+
+    def test_no_data_returns_unavailable(self):
+        """Sensor is unavailable when coordinator has no data."""
+        coordinator = _make_coordinator([])
+        coordinator.data = None
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor.available is False
+
+
+class TestStravaGearDistanceSensor:
+    """Tests for StravaGearDistanceSensor."""
+
+    def test_unique_id_uses_gear_id_not_index(self):
+        """unique_id must be based on the Strava gear ID."""
+        coordinator = _make_coordinator([GEAR_BIKE])
+        sensor = StravaGearDistanceSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor.unique_id == "strava_12345_gear_b111111_distance"
+
+    def test_gear_data_lookup_by_id(self):
+        """_gear_data finds the correct item regardless of list position."""
+        coordinator = _make_coordinator([GEAR_TRAINER, GEAR_SHOES, GEAR_BIKE])
+        sensor = StravaGearDistanceSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor._gear_data == GEAR_BIKE
+
+    def test_native_value_after_reorder(self):
+        """Distance value is stable even after gear list reorder."""
+        entry = MagicMock()
+        entry.title = "Strava: Test User"
+        entry.options = {
+            CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_METRIC
+        }
+        entry.data = {}
+        coordinator = _make_coordinator([GEAR_BIKE, GEAR_SHOES], entry=entry)
+        sensor = StravaGearDistanceSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        original_value = sensor.native_value
+
+        # Reorder list — same gear ID should return same distance
+        coordinator.data = {"gear": [GEAR_SHOES, GEAR_BIKE]}
+        assert sensor.native_value == original_value
+
+    def test_sensor_unavailable_when_gear_removed(self):
+        """Sensor becomes unavailable when gear is no longer in list."""
+        coordinator = _make_coordinator([GEAR_SHOES])
+        sensor = StravaGearDistanceSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor.available is False
+
+    def test_device_info_uses_gear_id(self):
+        """device_info identifiers use gear ID."""
+        coordinator = _make_coordinator([GEAR_BIKE])
+        sensor = StravaGearDistanceSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        identifiers = sensor.device_info["identifiers"]
+        assert (DOMAIN, "strava_12345_gear_b111111") in identifiers
+
+    def test_name_and_distance_sensor_share_device(self):
+        """Name and distance sensors for the same gear share a device (same device identifiers)."""
+        coordinator = _make_coordinator([GEAR_BIKE])
+        name_sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        dist_sensor = StravaGearDistanceSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert (
+            name_sensor.device_info["identifiers"]
+            == dist_sensor.device_info["identifiers"]
+        )


### PR DESCRIPTION
## Summary

- Fixes craibo/ha_strava#301 — gear sensor entities showing wrong gear name/data after sort order changes
- Root cause: `unique_id` and data lookup used a positional index in the distance-sorted gear list; when distances change the sort order shifts, associating each sensor with the wrong gear
- Fix: use the Strava gear's own stable ID (e.g. `b111111`) in `unique_id` generation and `_gear_data` lookup for both `StravaGearNameSensor` and `StravaGearDistanceSensor`
- Adds 15 new tests covering ID-based lookup and reorder stability
- Bumps version to 4.1.6

## Breaking change

Existing gear sensor `unique_id`s change from `strava_X_gear_0_name` → `strava_X_gear_b12345_name`. HA will treat these as new entities after upgrading — users will need to update dashboard cards referencing gear sensors.

## Test plan

- [ ] `pytest tests/custom_components/ha_strava/test_gear_sensors.py -v` — all 15 pass
- [ ] `pytest tests/` — no regressions vs develop baseline
- [ ] Manual: install on HA, verify gear sensor names and distances match the correct gear items after a data refresh