### PR TITLE
fix: preserve distance unit override when options form opened for the first time

### DIFF
--- a/custom_components/ha_strava/config_flow.py
+++ b/custom_components/ha_strava/config_flow.py
@@ -115,7 +115,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_DISTANCE_UNIT_OVERRIDE,
                         default=self.config_entry.options.get(
                             CONF_DISTANCE_UNIT_OVERRIDE,
-                            CONF_DISTANCE_UNIT_OVERRIDE_DEFAULT,
+                            self.config_entry.data.get(
+                                CONF_DISTANCE_UNIT_OVERRIDE,
+                                CONF_DISTANCE_UNIT_OVERRIDE_DEFAULT,
+                            ),
                         ),
                     ): vol.In(DISTANCE_UNIT_OVERRIDE_OPTIONS),
                     vol.Required(

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.1.6"
+  "version": "4.1.7"
 }

--- a/tests/custom_components/ha_strava/test_config_flow_units.py
+++ b/tests/custom_components/ha_strava/test_config_flow_units.py
@@ -1,0 +1,115 @@
+"""Tests for distance unit override persistence in the options flow (Issue #289)."""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+from custom_components.ha_strava.config_flow import OptionsFlowHandler
+from custom_components.ha_strava.const import (
+    CONF_DISTANCE_UNIT_OVERRIDE,
+    CONF_DISTANCE_UNIT_OVERRIDE_DEFAULT,
+    CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL,
+    CONF_DISTANCE_UNIT_OVERRIDE_METRIC,
+)
+
+
+def _get_schema_default(data_schema, key_name):
+    """Extract the default value for a named key from a voluptuous schema."""
+    for key in data_schema.schema:
+        if hasattr(key, "schema") and key.schema == key_name:
+            default = key.default
+            return default() if callable(default) else default
+    return None
+
+
+def _make_mock_entry(data: dict, options: dict):
+    """Create a minimal mock config entry."""
+    entry = MagicMock()
+    entry.data = data
+    entry.options = options
+    entry.title = "Strava: Test User"
+    return entry
+
+
+async def _show_form_with_entry(data: dict, options: dict):
+    """Instantiate OptionsFlowHandler, inject a mock config_entry, and return the form."""
+    mock_entry = _make_mock_entry(data, options)
+    flow = OptionsFlowHandler()
+
+    # HA's OptionsFlow.config_entry is a read-only property backed by hass.
+    # We patch it on the *class* for the duration of this call so that
+    # show_form_init() can access self.config_entry without the full HA runtime.
+    with patch.object(
+        OptionsFlowHandler, "config_entry", new_callable=PropertyMock
+    ) as mock_prop:
+        mock_prop.return_value = mock_entry
+        return await flow.show_form_init()
+
+
+class TestDistanceUnitOverrideDefault:
+    """Verify that the options form defaults correctly honour both options and data."""
+
+    @pytest.mark.asyncio
+    async def test_form_defaults_to_data_metric_when_options_empty(self):
+        """When options is empty and data has 'metric', the form should default to 'metric'.
+
+        This is the regression for Issue #289: previously the form fell back to
+        CONF_DISTANCE_UNIT_OVERRIDE_DEFAULT ('default') instead of reading entry.data,
+        silently overwriting the user's metric preference on first options submission.
+        """
+        result = await _show_form_with_entry(
+            data={CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_METRIC},
+            options={},
+        )
+        default = _get_schema_default(
+            result["data_schema"], CONF_DISTANCE_UNIT_OVERRIDE
+        )
+        assert default == CONF_DISTANCE_UNIT_OVERRIDE_METRIC, (
+            f"Expected form default '{CONF_DISTANCE_UNIT_OVERRIDE_METRIC}' "
+            f"from entry.data, got '{default}'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_form_defaults_to_data_imperial_when_options_empty(self):
+        """When options is empty and data has 'imperial', form should default to 'imperial'."""
+        result = await _show_form_with_entry(
+            data={CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL},
+            options={},
+        )
+        default = _get_schema_default(
+            result["data_schema"], CONF_DISTANCE_UNIT_OVERRIDE
+        )
+        assert default == CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL
+
+    @pytest.mark.asyncio
+    async def test_form_options_takes_precedence_over_data(self):
+        """When both options and data have a value, options takes precedence."""
+        result = await _show_form_with_entry(
+            data={CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_METRIC},
+            options={CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL},
+        )
+        default = _get_schema_default(
+            result["data_schema"], CONF_DISTANCE_UNIT_OVERRIDE
+        )
+        assert default == CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL
+
+    @pytest.mark.asyncio
+    async def test_form_falls_back_to_default_when_neither_options_nor_data_set(self):
+        """When neither options nor data have the key, fall back to the built-in default."""
+        result = await _show_form_with_entry(data={}, options={})
+        default = _get_schema_default(
+            result["data_schema"], CONF_DISTANCE_UNIT_OVERRIDE
+        )
+        assert default == CONF_DISTANCE_UNIT_OVERRIDE_DEFAULT
+
+    @pytest.mark.asyncio
+    async def test_form_options_metric_preserved(self):
+        """When options already has 'metric', it is shown correctly."""
+        result = await _show_form_with_entry(
+            data={},
+            options={CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_METRIC},
+        )
+        default = _get_schema_default(
+            result["data_schema"], CONF_DISTANCE_UNIT_OVERRIDE
+        )
+        assert default == CONF_DISTANCE_UNIT_OVERRIDE_METRIC


### PR DESCRIPTION
Fixes #289

## Summary

- The options form for `CONF_DISTANCE_UNIT_OVERRIDE` was not falling back to `entry.data` when the key was absent from `entry.options`, unlike `CONF_PHOTOS` and `CONF_GEAR_ENABLED` which already had this fallback
- On the user's first visit to the options form, the distance unit field showed `"default"` even if they had set `"metric"` during initial OAuth setup; submitting silently overwrote the preference with `"default"`
- After that point, `_is_metric()` returned `False` on imperial HA installs, causing YTD stats sensors to display miles/feet

## Root cause detail

`_is_metric()` reads `entry.options` first, then `entry.data`. When `entry.options` got `"default"` written to it (from the buggy form default), the `entry.data` value of `"metric"` was never reached. Activity sensors appeared correct because HA auto-converts their unit via `state_class = measurement`; stats sensors lacked this safety net.

## Changes

- `custom_components/ha_strava/config_flow.py` — add `entry.data` fallback for `CONF_DISTANCE_UNIT_OVERRIDE` default in options form (3-line change, mirrors existing pattern)
- `custom_components/ha_strava/manifest.json` — version bump to 4.1.7
- `tests/custom_components/ha_strava/test_config_flow_units.py` — 5 new tests covering the `options → data → built-in default` fallback chain

## Test plan

- [ ] `pytest tests/custom_components/ha_strava/test_config_flow_units.py -v` — all 5 new tests pass
- [ ] `pytest tests/ -v` — no regressions in passing tests
- [ ] `pre-commit run --all-files` — all hooks pass
- [ ] Manual: configure integration with "metric", open options, verify distance unit field shows "metric" not "default"