### PR TITLE
fix: Gear Sensors and Units of Measurement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ __pycache__/
 
 # Code assistants
 GEMINI.md
-CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Setup
+
+```bash
+# Create virtualenv and install all dependencies
+bash tools/setup_virtualenv.sh
+
+# Or manually:
+pip install -r requirements_dev.txt
+pip install -r requirements_test.txt
+pre-commit install
+```
+
+## Commands
+
+```bash
+# Run all tests
+python -m pytest
+
+# Run a single test file
+pytest tests/custom_components/ha_strava/test_coordinator.py -v
+
+# Run a specific test
+pytest tests/custom_components/ha_strava/test_sensor.py::test_name -v
+
+# Linting (also runs via pre-commit)
+black custom_components/ tests/
+isort custom_components/ tests/
+flake8 custom_components/ tests/
+pylint custom_components/ha_strava/
+```
+
+## Architecture
+
+This is a Home Assistant custom component integrating Strava athlete data. One config entry per Strava athlete (multi-user supported). `iot_class: cloud_push` — webhook-driven, not polled.
+
+**Entry point flow:**
+
+1. `async_setup_entry()` in `__init__.py` — sets up coordinator, registers `StravaWebhookView` at `/api/strava/webhook`, loads platforms (sensor, camera, button)
+2. `StravaDataUpdateCoordinator` (`coordinator.py`) — fetches activities, stats, gear, and photos via OAuth2 session; updates are triggered by webhooks, not a polling loop
+3. Webhook POST routes incoming events by `owner_id` to the correct coordinator (enabling multi-user)
+
+**Key modules:**
+
+| File             | Role                                                                               |
+| ---------------- | ---------------------------------------------------------------------------------- |
+| `__init__.py`    | Setup/teardown, webhook endpoint, webhook subscription                             |
+| `config_flow.py` | OAuth2 auth flow + options flow (activity types, gear, photos, units)              |
+| `coordinator.py` | Strava API calls, data caching, exponential backoff                                |
+| `sensor.py`      | All sensor entities: per-activity-type metrics, recent activities, summaries, gear |
+| `camera.py`      | Photo carousel (up to 30 images, 24h cache)                                        |
+| `button.py`      | Manual refresh buttons per activity type                                           |
+| `const.py`       | All constants: OAuth URLs, 50+ activity types, config keys, sensor attributes      |
+
+**Multi-user:**
+Each Strava account requires its own Strava API app (Strava limits one athlete per app). `unique_id` for each config entry = athlete ID. Webhook handler matches `owner_id` to route to the correct entry's coordinator.
+
+**OAuth2:**
+Uses `config_entry_oauth2_flow.OAuth2Session` with `LocalOAuth2Implementation`. Authorization callback domain must be `my.home-assistant.io`.
+
+**Webhook lifecycle:**
+`renew_webhook_subscription()` in `__init__.py` calls Strava's webhook API to (re)register. Subscription ID persists in the config entry. On unload, the subscription is deleted.
+
+## Code Standards
+
+- Max line length: 120 characters (Black, flake8, pylint all configured to this)
+- Type hints required on all functions
+- Pre-commit hooks enforce black, isort, flake8, pylint — run `pre-commit run --all-files` to check
+
+## Testing Patterns
+
+Tests use `pytest-homeassistant-custom-component`. Fixtures live in `tests/custom_components/ha_strava/conftest.py` — it provides `mock_config_entry`, `mock_strava_activities`, `mock_oauth_flow`, and other standard fixtures.
+
+```python
+async def test_example(hass, mock_config_entry):
+    # Use hass fixture from pytest-homeassistant-custom-component
+    ...
+```
+
+`asyncio_mode = auto` is set in `pytest.ini`, so async tests don't need `@pytest.mark.asyncio`.
+
+## Strava API Constraints
+
+- Rate limits: 100 requests/15 min, 1000 requests/day — coordinator caches aggressively and retries with exponential backoff (max 3 attempts)
+- Activities endpoint returns max 200 per call
+- Photos cached for 24 hours

--- a/custom_components/ha_strava/config_flow.py
+++ b/custom_components/ha_strava/config_flow.py
@@ -115,7 +115,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_DISTANCE_UNIT_OVERRIDE,
                         default=self.config_entry.options.get(
                             CONF_DISTANCE_UNIT_OVERRIDE,
-                            CONF_DISTANCE_UNIT_OVERRIDE_DEFAULT,
+                            self.config_entry.data.get(
+                                CONF_DISTANCE_UNIT_OVERRIDE,
+                                CONF_DISTANCE_UNIT_OVERRIDE_DEFAULT,
+                            ),
                         ),
                     ): vol.In(DISTANCE_UNIT_OVERRIDE_OPTIONS),
                     vol.Required(

--- a/custom_components/ha_strava/const.py
+++ b/custom_components/ha_strava/const.py
@@ -581,9 +581,9 @@ def generate_recent_activity_sensor_name(
     )
 
 
-def generate_gear_device_id(athlete_id: str, gear_index: int) -> str:
+def generate_gear_device_id(athlete_id: str, gear_id: str) -> str:
     """Generate standardized gear device ID."""
-    return f"strava_{athlete_id}_gear_{gear_index}"
+    return f"strava_{athlete_id}_gear_{gear_id}"
 
 
 def generate_gear_device_name(athlete_name: str, gear_name: str) -> str:
@@ -591,9 +591,9 @@ def generate_gear_device_name(athlete_name: str, gear_name: str) -> str:
     return f"Strava {athlete_name} {gear_name}"
 
 
-def generate_gear_sensor_id(athlete_id: str, gear_index: int, sensor_type: str) -> str:
+def generate_gear_sensor_id(athlete_id: str, gear_id: str, sensor_type: str) -> str:
     """Generate standardized gear sensor ID."""
-    return f"strava_{athlete_id}_gear_{gear_index}_{sensor_type}"
+    return f"strava_{athlete_id}_gear_{gear_id}_{sensor_type}"
 
 
 def generate_gear_sensor_name(

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.1.5"
+  "version": "4.1.6"
 }

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.1.6"
+  "version": "4.1.7"
 }

--- a/custom_components/ha_strava/sensor.py
+++ b/custom_components/ha_strava/sensor.py
@@ -280,18 +280,21 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     # Create gear sensors if enabled
     if gear_enabled:
         gear_data = coordinator.data.get("gear") if coordinator.data else []
-        for gear_index, _gear_item in enumerate(gear_data):
+        for gear_item in gear_data:
+            gear_id = str(gear_item.get("id", ""))
+            if not gear_id:
+                continue
             entries.append(
                 StravaGearNameSensor(
                     coordinator,
-                    gear_index=gear_index,
+                    gear_id=gear_id,
                     athlete_id=athlete_id,
                 )
             )
             entries.append(
                 StravaGearDistanceSensor(
                     coordinator,
-                    gear_index=gear_index,
+                    gear_id=gear_id,
                     athlete_id=athlete_id,
                 )
             )
@@ -1715,28 +1718,28 @@ class StravaGearNameSensor(CoordinatorEntity, SensorEntity):
     def __init__(
         self,
         coordinator: StravaDataUpdateCoordinator,
-        gear_index: int,
+        gear_id: str,
         athlete_id: str,
     ):
         """Initialize the sensor."""
         super().__init__(coordinator)
-        self._gear_index = gear_index
+        self._gear_id = gear_id
         self._athlete_id = athlete_id
         self._athlete_name = get_athlete_name_from_title(self.coordinator.entry.title)
-        self._attr_unique_id = generate_gear_sensor_id(athlete_id, gear_index, "name")
+        self._attr_unique_id = generate_gear_sensor_id(athlete_id, gear_id, "name")
 
     @property
     def device_info(self):
         """Return device information."""
         gear_data = self._gear_data
         gear_name = (
-            gear_data.get("name", f"Gear {self._gear_index + 1}")
+            gear_data.get("name", f"Gear {self._gear_id}")
             if gear_data
-            else f"Gear {self._gear_index + 1}"
+            else f"Gear {self._gear_id}"
         )
         return {
             "identifiers": {
-                (DOMAIN, generate_gear_device_id(self._athlete_id, self._gear_index))
+                (DOMAIN, generate_gear_device_id(self._athlete_id, self._gear_id))
             },
             "name": generate_gear_device_name(self._athlete_name, gear_name),
             "manufacturer": "Powered by Strava",
@@ -1749,9 +1752,9 @@ class StravaGearNameSensor(CoordinatorEntity, SensorEntity):
         """Get the gear data for this sensor."""
         if not self.coordinator.data or not self.coordinator.data.get("gear"):
             return None
-        gear_list = self.coordinator.data["gear"]
-        if self._gear_index < len(gear_list):
-            return gear_list[self._gear_index]
+        for gear_item in self.coordinator.data["gear"]:
+            if str(gear_item.get("id", "")) == self._gear_id:
+                return gear_item
         return None
 
     @property
@@ -1770,16 +1773,16 @@ class StravaGearNameSensor(CoordinatorEntity, SensorEntity):
         if not self.available:
             return None
         gear_data = self._gear_data
-        return gear_data.get("name", f"Gear {self._gear_index + 1}")
+        return gear_data.get("name", f"Gear {self._gear_id}")
 
     @property
     def name(self):
         """Return the name of the sensor."""
         gear_data = self._gear_data
         gear_name = (
-            gear_data.get("name", f"Gear {self._gear_index + 1}")
+            gear_data.get("name", f"Gear {self._gear_id}")
             if gear_data
-            else f"Gear {self._gear_index + 1}"
+            else f"Gear {self._gear_id}"
         )
         return generate_gear_sensor_name(self._athlete_name, gear_name, "name")
 
@@ -1812,30 +1815,28 @@ class StravaGearDistanceSensor(CoordinatorEntity, SensorEntity):
     def __init__(
         self,
         coordinator: StravaDataUpdateCoordinator,
-        gear_index: int,
+        gear_id: str,
         athlete_id: str,
     ):
         """Initialize the sensor."""
         super().__init__(coordinator)
-        self._gear_index = gear_index
+        self._gear_id = gear_id
         self._athlete_id = athlete_id
         self._athlete_name = get_athlete_name_from_title(self.coordinator.entry.title)
-        self._attr_unique_id = generate_gear_sensor_id(
-            athlete_id, gear_index, "distance"
-        )
+        self._attr_unique_id = generate_gear_sensor_id(athlete_id, gear_id, "distance")
 
     @property
     def device_info(self):
         """Return device information."""
         gear_data = self._gear_data
         gear_name = (
-            gear_data.get("name", f"Gear {self._gear_index + 1}")
+            gear_data.get("name", f"Gear {self._gear_id}")
             if gear_data
-            else f"Gear {self._gear_index + 1}"
+            else f"Gear {self._gear_id}"
         )
         return {
             "identifiers": {
-                (DOMAIN, generate_gear_device_id(self._athlete_id, self._gear_index))
+                (DOMAIN, generate_gear_device_id(self._athlete_id, self._gear_id))
             },
             "name": generate_gear_device_name(self._athlete_name, gear_name),
             "manufacturer": "Powered by Strava",
@@ -1848,9 +1849,9 @@ class StravaGearDistanceSensor(CoordinatorEntity, SensorEntity):
         """Get the gear data for this sensor."""
         if not self.coordinator.data or not self.coordinator.data.get("gear"):
             return None
-        gear_list = self.coordinator.data["gear"]
-        if self._gear_index < len(gear_list):
-            return gear_list[self._gear_index]
+        for gear_item in self.coordinator.data["gear"]:
+            if str(gear_item.get("id", "")) == self._gear_id:
+                return gear_item
         return None
 
     @property
@@ -1895,9 +1896,9 @@ class StravaGearDistanceSensor(CoordinatorEntity, SensorEntity):
         """Return the name of the sensor."""
         gear_data = self._gear_data
         gear_name = (
-            gear_data.get("name", f"Gear {self._gear_index + 1}")
+            gear_data.get("name", f"Gear {self._gear_id}")
             if gear_data
-            else f"Gear {self._gear_index + 1}"
+            else f"Gear {self._gear_id}"
         )
         return generate_gear_sensor_name(self._athlete_name, gear_name, "distance")
 

--- a/tests/custom_components/ha_strava/test_config_flow_units.py
+++ b/tests/custom_components/ha_strava/test_config_flow_units.py
@@ -1,0 +1,115 @@
+"""Tests for distance unit override persistence in the options flow (Issue #289)."""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+from custom_components.ha_strava.config_flow import OptionsFlowHandler
+from custom_components.ha_strava.const import (
+    CONF_DISTANCE_UNIT_OVERRIDE,
+    CONF_DISTANCE_UNIT_OVERRIDE_DEFAULT,
+    CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL,
+    CONF_DISTANCE_UNIT_OVERRIDE_METRIC,
+)
+
+
+def _get_schema_default(data_schema, key_name):
+    """Extract the default value for a named key from a voluptuous schema."""
+    for key in data_schema.schema:
+        if hasattr(key, "schema") and key.schema == key_name:
+            default = key.default
+            return default() if callable(default) else default
+    return None
+
+
+def _make_mock_entry(data: dict, options: dict):
+    """Create a minimal mock config entry."""
+    entry = MagicMock()
+    entry.data = data
+    entry.options = options
+    entry.title = "Strava: Test User"
+    return entry
+
+
+async def _show_form_with_entry(data: dict, options: dict):
+    """Instantiate OptionsFlowHandler, inject a mock config_entry, and return the form."""
+    mock_entry = _make_mock_entry(data, options)
+    flow = OptionsFlowHandler()
+
+    # HA's OptionsFlow.config_entry is a read-only property backed by hass.
+    # We patch it on the *class* for the duration of this call so that
+    # show_form_init() can access self.config_entry without the full HA runtime.
+    with patch.object(
+        OptionsFlowHandler, "config_entry", new_callable=PropertyMock
+    ) as mock_prop:
+        mock_prop.return_value = mock_entry
+        return await flow.show_form_init()
+
+
+class TestDistanceUnitOverrideDefault:
+    """Verify that the options form defaults correctly honour both options and data."""
+
+    @pytest.mark.asyncio
+    async def test_form_defaults_to_data_metric_when_options_empty(self):
+        """When options is empty and data has 'metric', the form should default to 'metric'.
+
+        This is the regression for Issue #289: previously the form fell back to
+        CONF_DISTANCE_UNIT_OVERRIDE_DEFAULT ('default') instead of reading entry.data,
+        silently overwriting the user's metric preference on first options submission.
+        """
+        result = await _show_form_with_entry(
+            data={CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_METRIC},
+            options={},
+        )
+        default = _get_schema_default(
+            result["data_schema"], CONF_DISTANCE_UNIT_OVERRIDE
+        )
+        assert default == CONF_DISTANCE_UNIT_OVERRIDE_METRIC, (
+            f"Expected form default '{CONF_DISTANCE_UNIT_OVERRIDE_METRIC}' "
+            f"from entry.data, got '{default}'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_form_defaults_to_data_imperial_when_options_empty(self):
+        """When options is empty and data has 'imperial', form should default to 'imperial'."""
+        result = await _show_form_with_entry(
+            data={CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL},
+            options={},
+        )
+        default = _get_schema_default(
+            result["data_schema"], CONF_DISTANCE_UNIT_OVERRIDE
+        )
+        assert default == CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL
+
+    @pytest.mark.asyncio
+    async def test_form_options_takes_precedence_over_data(self):
+        """When both options and data have a value, options takes precedence."""
+        result = await _show_form_with_entry(
+            data={CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_METRIC},
+            options={CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL},
+        )
+        default = _get_schema_default(
+            result["data_schema"], CONF_DISTANCE_UNIT_OVERRIDE
+        )
+        assert default == CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL
+
+    @pytest.mark.asyncio
+    async def test_form_falls_back_to_default_when_neither_options_nor_data_set(self):
+        """When neither options nor data have the key, fall back to the built-in default."""
+        result = await _show_form_with_entry(data={}, options={})
+        default = _get_schema_default(
+            result["data_schema"], CONF_DISTANCE_UNIT_OVERRIDE
+        )
+        assert default == CONF_DISTANCE_UNIT_OVERRIDE_DEFAULT
+
+    @pytest.mark.asyncio
+    async def test_form_options_metric_preserved(self):
+        """When options already has 'metric', it is shown correctly."""
+        result = await _show_form_with_entry(
+            data={},
+            options={CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_METRIC},
+        )
+        default = _get_schema_default(
+            result["data_schema"], CONF_DISTANCE_UNIT_OVERRIDE
+        )
+        assert default == CONF_DISTANCE_UNIT_OVERRIDE_METRIC

--- a/tests/custom_components/ha_strava/test_gear_sensors.py
+++ b/tests/custom_components/ha_strava/test_gear_sensors.py
@@ -1,0 +1,216 @@
+"""Test gear sensors for ha_strava."""
+
+from unittest.mock import MagicMock
+
+from custom_components.ha_strava.const import (
+    CONF_DISTANCE_UNIT_OVERRIDE,
+    CONF_DISTANCE_UNIT_OVERRIDE_METRIC,
+    DOMAIN,
+)
+from custom_components.ha_strava.sensor import (
+    StravaGearDistanceSensor,
+    StravaGearNameSensor,
+)
+
+
+def _make_coordinator(gear_list, entry=None):
+    """Return a mock coordinator with the given gear list."""
+    coordinator = MagicMock()
+    coordinator.data = {"gear": gear_list}
+    if entry is None:
+        entry = MagicMock()
+        entry.title = "Strava: Test User"
+        entry.options = {}
+        entry.data = {}
+    coordinator.entry = entry
+    return coordinator
+
+
+GEAR_BIKE = {
+    "id": "b111111",
+    "name": "CGR SL",
+    "distance": 8000000.0,
+    "brand_name": "Genesis",
+    "model_name": "CGR SL",
+    "primary": True,
+    "description": "Gravel bike",
+}
+
+GEAR_SHOES = {
+    "id": "g222222",
+    "name": "Running Shoes",
+    "distance": 3000000.0,
+    "brand_name": "Nike",
+    "model_name": "Pegasus",
+    "primary": False,
+    "description": "",
+}
+
+GEAR_TRAINER = {
+    "id": "b333333",
+    "name": "Indoor Trainer",
+    "distance": 1000000.0,
+    "brand_name": "Wahoo",
+    "model_name": "KICKR",
+    "primary": False,
+    "description": "Smart trainer",
+}
+
+
+class TestStravaGearNameSensor:
+    """Tests for StravaGearNameSensor."""
+
+    def test_unique_id_uses_gear_id_not_index(self):
+        """unique_id must be stable and based on the Strava gear ID."""
+        coordinator = _make_coordinator([GEAR_BIKE, GEAR_SHOES])
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor.unique_id == "strava_12345_gear_b111111_name"
+
+    def test_unique_id_is_independent_of_list_position(self):
+        """Two sensors for different gear must have different unique_ids regardless of order."""
+        coordinator = _make_coordinator([GEAR_SHOES, GEAR_BIKE])
+        s1 = StravaGearNameSensor(coordinator, gear_id="b111111", athlete_id="12345")
+        s2 = StravaGearNameSensor(coordinator, gear_id="g222222", athlete_id="12345")
+        assert s1.unique_id != s2.unique_id
+        assert s1.unique_id == "strava_12345_gear_b111111_name"
+        assert s2.unique_id == "strava_12345_gear_g222222_name"
+
+    def test_gear_data_lookup_by_id(self):
+        """_gear_data returns the correct item regardless of its position in the list."""
+        # GEAR_SHOES is at index 0, GEAR_BIKE at index 1 (reversed order)
+        coordinator = _make_coordinator([GEAR_SHOES, GEAR_BIKE])
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor._gear_data == GEAR_BIKE
+
+    def test_native_value_after_reorder(self):
+        """native_value returns the correct gear name even after the list is reordered."""
+        # Initially: GEAR_BIKE first
+        coordinator = _make_coordinator([GEAR_BIKE, GEAR_SHOES])
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor.native_value == "CGR SL"
+
+        # Simulate reorder: GEAR_SHOES now first (e.g. distance changed)
+        coordinator.data = {"gear": [GEAR_SHOES, GEAR_TRAINER, GEAR_BIKE]}
+        assert sensor.native_value == "CGR SL"
+
+    def test_sensor_unavailable_when_gear_id_missing(self):
+        """Sensor is unavailable when its gear ID is no longer in the list."""
+        coordinator = _make_coordinator([GEAR_SHOES])
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor.available is False
+        assert sensor.native_value is None
+
+    def test_name_property(self):
+        """name property returns a human-readable name using gear's own name."""
+        coordinator = _make_coordinator([GEAR_BIKE])
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor.name == "Strava Test User CGR SL Name"
+
+    def test_device_info_uses_gear_id(self):
+        """device_info identifiers must be based on gear ID, not index."""
+        coordinator = _make_coordinator([GEAR_BIKE])
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        identifiers = sensor.device_info["identifiers"]
+        assert (DOMAIN, "strava_12345_gear_b111111") in identifiers
+
+    def test_extra_state_attributes(self):
+        """extra_state_attributes exposes gear metadata."""
+        coordinator = _make_coordinator([GEAR_BIKE])
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["id"] == "b111111"
+        assert attrs["brand_name"] == "Genesis"
+        assert attrs["model_name"] == "CGR SL"
+        assert attrs["primary"] is True
+
+    def test_no_data_returns_unavailable(self):
+        """Sensor is unavailable when coordinator has no data."""
+        coordinator = _make_coordinator([])
+        coordinator.data = None
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor.available is False
+
+
+class TestStravaGearDistanceSensor:
+    """Tests for StravaGearDistanceSensor."""
+
+    def test_unique_id_uses_gear_id_not_index(self):
+        """unique_id must be based on the Strava gear ID."""
+        coordinator = _make_coordinator([GEAR_BIKE])
+        sensor = StravaGearDistanceSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor.unique_id == "strava_12345_gear_b111111_distance"
+
+    def test_gear_data_lookup_by_id(self):
+        """_gear_data finds the correct item regardless of list position."""
+        coordinator = _make_coordinator([GEAR_TRAINER, GEAR_SHOES, GEAR_BIKE])
+        sensor = StravaGearDistanceSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor._gear_data == GEAR_BIKE
+
+    def test_native_value_after_reorder(self):
+        """Distance value is stable even after gear list reorder."""
+        entry = MagicMock()
+        entry.title = "Strava: Test User"
+        entry.options = {
+            CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_METRIC
+        }
+        entry.data = {}
+        coordinator = _make_coordinator([GEAR_BIKE, GEAR_SHOES], entry=entry)
+        sensor = StravaGearDistanceSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        original_value = sensor.native_value
+
+        # Reorder list — same gear ID should return same distance
+        coordinator.data = {"gear": [GEAR_SHOES, GEAR_BIKE]}
+        assert sensor.native_value == original_value
+
+    def test_sensor_unavailable_when_gear_removed(self):
+        """Sensor becomes unavailable when gear is no longer in list."""
+        coordinator = _make_coordinator([GEAR_SHOES])
+        sensor = StravaGearDistanceSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert sensor.available is False
+
+    def test_device_info_uses_gear_id(self):
+        """device_info identifiers use gear ID."""
+        coordinator = _make_coordinator([GEAR_BIKE])
+        sensor = StravaGearDistanceSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        identifiers = sensor.device_info["identifiers"]
+        assert (DOMAIN, "strava_12345_gear_b111111") in identifiers
+
+    def test_name_and_distance_sensor_share_device(self):
+        """Name and distance sensors for the same gear share a device (same device identifiers)."""
+        coordinator = _make_coordinator([GEAR_BIKE])
+        name_sensor = StravaGearNameSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        dist_sensor = StravaGearDistanceSensor(
+            coordinator, gear_id="b111111", athlete_id="12345"
+        )
+        assert (
+            name_sensor.device_info["identifiers"]
+            == dist_sensor.device_info["identifiers"]
+        )


### PR DESCRIPTION
[fix: use stable gear ID instead of index for gear sensor unique_id (Issue https://github.com/craibo/ha_strava/issues/301)](https://github.com/craibo/ha_strava/commit/37cf521adae2f6477921378ac9479782c88f8b9c) 

[fix: preserve distance unit override when options form is opened for the first time (Issue https://github.com/craibo/ha_strava/issues/289)](https://github.com/craibo/ha_strava/commit/cbad15cb309dc4db6979d359c973a84a9784b700) 

Bumps version to 4.1.7.