### PR TITLE
fix: gear sensor stability and options form defaults

### DIFF
--- a/custom_components/ha_strava/__init__.py
+++ b/custom_components/ha_strava/__init__.py
@@ -7,12 +7,15 @@ from urllib.parse import urlparse
 
 import aiohttp
 import homeassistant.helpers.config_validation as cv
+import homeassistant.helpers.device_registry as dr
 from aiohttp.web import Request, Response, json_response
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_WEBHOOK_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.entity_registry import async_entries_for_config_entry
+from homeassistant.helpers.entity_registry import async_get as er_async_get
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 
 from .const import CONF_CALLBACK_URL, DOMAIN, WEBHOOK_SUBSCRIPTION_URL
@@ -32,6 +35,7 @@ def _normalize_callback_url(url: str) -> str:
         return normalized
     except Exception:
         return url.strip().rstrip("/")
+
 
 PLATFORMS = ["sensor", "camera", "button"]
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
@@ -147,9 +151,7 @@ async def renew_webhook_subscription(
                 )
             return False
         except aiohttp.ClientError as err:
-            _LOGGER.warning(
-                "Failed to delete webhook subscription %s: %s", sub_id, err
-            )
+            _LOGGER.warning("Failed to delete webhook subscription %s: %s", sub_id, err)
             return False
 
     try:
@@ -188,18 +190,14 @@ async def renew_webhook_subscription(
                 continue
             sub_normalized = _normalize_callback_url(sub_url)
             if sub_normalized != normalized_callback_url:
-                _LOGGER.info(
-                    "Deleting outdated webhook subscription: %s", sub_id
-                )
+                _LOGGER.info("Deleting outdated webhook subscription: %s", sub_id)
                 if sub_id is not None:
                     await _delete_subscription_async(int(sub_id))
             else:
                 matching_sub = sub
 
         if matching_sub is not None:
-            _LOGGER.debug(
-                "Existing webhook URL confirmed for %s", callback_url
-            )
+            _LOGGER.debug("Existing webhook URL confirmed for %s", callback_url)
             mutable_data = {**entry.data}
             mutable_data[CONF_WEBHOOK_ID] = matching_sub["id"]
             hass.config_entries.async_update_entry(entry, data=mutable_data)
@@ -207,16 +205,12 @@ async def renew_webhook_subscription(
 
     except aiohttp.ClientError as err:
         _LOGGER.error("Error managing webhook subscriptions: %s", err)
-        _LOGGER.debug(
-            "Webhook URL mismatch or unconfirmed; deleting and re-creating."
-        )
+        _LOGGER.debug("Webhook URL mismatch or unconfirmed; deleting and re-creating.")
         stored_id = entry.data.get(CONF_WEBHOOK_ID)
         if stored_id is not None:
             await _delete_subscription_async(int(stored_id))
     else:
-        _LOGGER.info(
-            "Webhook URL mismatch or unconfirmed; deleting and re-creating."
-        )
+        _LOGGER.info("Webhook URL mismatch or unconfirmed; deleting and re-creating.")
 
     try:
         _LOGGER.debug("Creating new webhook subscription for %s", callback_url)
@@ -240,6 +234,56 @@ async def renew_webhook_subscription(
         _LOGGER.error("Error creating webhook subscription: %s", err)
 
 
+def _remove_legacy_gear_entries(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Remove gear entities/devices that use the old index-based unique_id format.
+
+    Before commit 37cf521 gear sensors used a positional index (0, 1, 2 …) in
+    their unique_id.  The fix switched to the stable Strava gear ID (e.g. b111111).
+    Old registry entries must be explicitly removed so they are not left as
+    orphaned/unavailable sensors alongside the new ones.
+    """
+    athlete_id = entry.unique_id
+    if not athlete_id:
+        return
+
+    entity_registry = er_async_get(hass)
+    for entity in async_entries_for_config_entry(entity_registry, entry.entry_id):
+        uid = entity.unique_id or ""
+        uid_parts = uid.split("_")
+        # Old format: strava_{athlete_id}_gear_{numeric_index}_{sensor_type}
+        if (
+            len(uid_parts) >= 4
+            and uid_parts[0] == "strava"
+            and uid_parts[1] == athlete_id
+            and uid_parts[2] == "gear"
+            and uid_parts[3].isdigit()
+        ):
+            _LOGGER.info(
+                "Removing legacy index-based gear entity: %s", entity.entity_id
+            )
+            entity_registry.async_remove(entity.entity_id)
+
+    device_registry = dr.async_get(hass)
+    for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
+        for identifier in device.identifiers:
+            if identifier[0] != DOMAIN:
+                continue
+            did_parts = identifier[1].split("_")
+            # Old format: strava_{athlete_id}_gear_{numeric_index}
+            if (
+                len(did_parts) >= 4
+                and did_parts[0] == "strava"
+                and did_parts[1] == athlete_id
+                and did_parts[2] == "gear"
+                and did_parts[3].isdigit()
+            ):
+                _LOGGER.info(
+                    "Removing legacy index-based gear device: %s", identifier[1]
+                )
+                device_registry.async_remove_device(device.id)
+            break
+
+
 async def async_setup(
     hass: HomeAssistant, config: dict
 ):  # pylint: disable=unused-argument
@@ -255,6 +299,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     await coordinator.async_config_entry_first_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
+
+    # Remove any gear entities/devices left over from the old index-based unique_id format
+    _remove_legacy_gear_entries(hass, entry)
 
     # Set up webhook
     hass.http.register_view(StravaWebhookView(hass))

--- a/custom_components/ha_strava/config_flow.py
+++ b/custom_components/ha_strava/config_flow.py
@@ -267,29 +267,24 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         continue
 
                     # Handle gear devices
-                    # Format: strava_{athlete_id}_gear_{index}
+                    # Old format: strava_{athlete_id}_gear_{numeric_index}
+                    # New format: strava_{athlete_id}_gear_{gear_id}  (e.g. "b111111")
                     if device_type == "gear":
                         gear_enabled = user_input.get(CONF_GEAR_ENABLED, False)
-                        new_num_gear_sensors = user_input.get(CONF_NUM_GEAR_SENSORS, 0)
 
                         if not gear_enabled:
                             # Remove all gear devices if gear sensors are disabled
                             _device_registry.async_remove_device(device.id)
                             continue
 
-                        # Extract gear index from device identifier
                         if len(parts) >= 4 and parts[3].isdigit():
-                            gear_index = int(parts[3])
-                            # Remove if gear_index >= new_num_gear_sensors (0-indexed, so >= means out of range)
-                            if gear_index >= new_num_gear_sensors:
-                                _device_registry.async_remove_device(device.id)
-                            else:
-                                _device_registry.async_update_device(
-                                    device.id, disabled_by=None
-                                )
-                        else:
-                            # Malformed gear device identifier, remove it
+                            # Legacy index-based format — remove it
                             _device_registry.async_remove_device(device.id)
+                        else:
+                            # New gear_id format — keep and enable
+                            _device_registry.async_update_device(
+                                device.id, disabled_by=None
+                            )
                         continue
 
                     # Handle activity type devices (skip "stats")
@@ -432,24 +427,20 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                                         # Remove excess recent activity entities (not disable)
                                         _entity_registry.async_remove(entity.entity_id)
                         # Handle gear entities
-                        # Format: strava_{athlete_id}_gear_{index}_{sensor_type}
+                        # Old format: strava_{athlete_id}_gear_{numeric_index}_{sensor_type}
+                        # New format: strava_{athlete_id}_gear_{gear_id}_{sensor_type}  (e.g. "b111111")
                         elif "_gear_" in entity.entity_id:
                             gear_enabled = user_input.get(CONF_GEAR_ENABLED, False)
-                            new_num_gear_sensors = user_input.get(
-                                CONF_NUM_GEAR_SENSORS, 0
-                            )
 
                             if not gear_enabled:
                                 # Remove all gear entities if gear sensors are disabled
                                 _entity_registry.async_remove(entity.entity_id)
                                 continue
 
-                            # Extract gear index from entity ID
                             # Remove "sensor." prefix if present
                             entity_id = entity.entity_id.split(".", 1)[-1]
                             parts = entity_id.split("_")
 
-                            # Format: strava_{athlete_id}_gear_{index} or strava_{athlete_id}_gear_{index}_{sensor_type}
                             if (
                                 len(parts) >= 4
                                 and parts[0] == "strava"
@@ -457,17 +448,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                                 and parts[2] == "gear"
                                 and parts[3].isdigit()
                             ):
-                                gear_index = int(parts[3])
-                                # Remove if gear_index >= new_num_gear_sensors (0-indexed, so >= means out of range)
-                                if gear_index >= new_num_gear_sensors:
-                                    _entity_registry.async_remove(entity.entity_id)
-                                else:
-                                    _entity_registry.async_update_entity(
-                                        entity.entity_id, disabled_by=None
-                                    )
-                            else:
-                                # Malformed gear entity identifier, remove it
+                                # Legacy index-based format — remove it
                                 _entity_registry.async_remove(entity.entity_id)
+                            else:
+                                # New gear_id format — keep and enable
+                                _entity_registry.async_update_entity(
+                                    entity.entity_id, disabled_by=None
+                                )
                     except (ValueError, IndexError, AttributeError) as e:
                         # Skip entities that don't match expected format
                         _LOGGER.debug(

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.1.7"
+  "version": "4.1.8"
 }

--- a/tests/custom_components/ha_strava/test_config_flow_entity_cleanup.py
+++ b/tests/custom_components/ha_strava/test_config_flow_entity_cleanup.py
@@ -1,6 +1,6 @@
 """Test config flow entity cleanup for multiple recent activity devices."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
@@ -10,6 +10,8 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.ha_strava.config_flow import OptionsFlowHandler
 from custom_components.ha_strava.const import (
     CONF_ACTIVITY_TYPES_TO_TRACK,
+    CONF_GEAR_ENABLED,
+    CONF_NUM_GEAR_SENSORS,
     CONF_NUM_RECENT_ACTIVITIES,
     DOMAIN,
 )
@@ -497,3 +499,269 @@ class TestEntityCleanupInOptionsFlow:
                     for call in call_args_list
                 )
                 assert valid_entity_processed, "Valid entity should have been processed"
+
+
+_BASE_USER_INPUT = {
+    CONF_ACTIVITY_TYPES_TO_TRACK: ["Run"],
+    CONF_NUM_RECENT_ACTIVITIES: 1,
+    "conf_photos": False,
+    "img_update_interval_seconds": 300,
+    CONF_NUM_GEAR_SENSORS: 3,
+}
+
+
+def _make_config_entry(gear_enabled: bool = True):
+    return MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="12345",
+        data={
+            CONF_CLIENT_ID: "test_client_id",
+            CONF_CLIENT_SECRET: "test_client_secret",
+        },
+        options={
+            CONF_ACTIVITY_TYPES_TO_TRACK: ["Run"],
+            CONF_NUM_RECENT_ACTIVITIES: 1,
+            CONF_GEAR_ENABLED: gear_enabled,
+            CONF_NUM_GEAR_SENSORS: 3,
+        },
+        title="Strava: Test User",
+    )
+
+
+async def _run_gear_options_save(hass, config_entry, entities, devices, gear_enabled):
+    """Helper: invoke async_step_init with mocked registries and return the mocks."""
+    entity_registry = MagicMock()
+    device_registry = MagicMock()
+    user_input = {**_BASE_USER_INPUT, CONF_GEAR_ENABLED: gear_enabled}
+
+    flow = OptionsFlowHandler()
+    flow.hass = hass
+
+    with patch.object(
+        OptionsFlowHandler,
+        "config_entry",
+        new_callable=PropertyMock,
+        return_value=config_entry,
+    ), patch(
+        "custom_components.ha_strava.config_flow.async_get",
+        return_value=entity_registry,
+    ), patch(
+        "custom_components.ha_strava.config_flow.async_entries_for_config_entry",
+        return_value=entities,
+    ), patch(
+        "custom_components.ha_strava.config_flow.dr.async_get",
+        return_value=device_registry,
+    ), patch(
+        "custom_components.ha_strava.config_flow.dr.async_entries_for_config_entry",
+        return_value=devices,
+    ), patch.object(
+        flow, "async_create_entry"
+    ):
+        await flow.async_step_init(user_input)
+
+    return entity_registry, device_registry
+
+
+class TestGearEntityCleanupInOptionsFlow:
+    """Test gear entity/device cleanup in options flow after the unique_id migration."""
+
+    @pytest.mark.asyncio
+    async def test_legacy_gear_entity_removed_on_options_save(
+        self, hass: HomeAssistant
+    ):
+        """Old index-based gear entities are removed when options are saved with gear enabled."""
+        legacy_name = MagicMock()
+        legacy_name.entity_id = "sensor.strava_12345_gear_0_name"
+        legacy_name.unique_id = "strava_12345_gear_0_name"
+
+        legacy_distance = MagicMock()
+        legacy_distance.entity_id = "sensor.strava_12345_gear_0_distance"
+        legacy_distance.unique_id = "strava_12345_gear_0_distance"
+
+        entity_registry, _ = await _run_gear_options_save(
+            hass, _make_config_entry(), [legacy_name, legacy_distance], [], True
+        )
+
+        removed = [call[0][0] for call in entity_registry.async_remove.call_args_list]
+        assert "sensor.strava_12345_gear_0_name" in removed
+        assert "sensor.strava_12345_gear_0_distance" in removed
+
+        # Should NOT have been enabled
+        enabled = [
+            call[0][0] for call in entity_registry.async_update_entity.call_args_list
+        ]
+        assert "sensor.strava_12345_gear_0_name" not in enabled
+
+    @pytest.mark.asyncio
+    async def test_new_format_gear_entity_preserved_on_options_save(
+        self, hass: HomeAssistant
+    ):
+        """New gear_id-based entities are kept and enabled when options are saved with gear enabled."""
+        new_name = MagicMock()
+        new_name.entity_id = "sensor.strava_12345_gear_b111111_name"
+        new_name.unique_id = "strava_12345_gear_b111111_name"
+
+        new_distance = MagicMock()
+        new_distance.entity_id = "sensor.strava_12345_gear_b111111_distance"
+        new_distance.unique_id = "strava_12345_gear_b111111_distance"
+
+        entity_registry, _ = await _run_gear_options_save(
+            hass, _make_config_entry(), [new_name, new_distance], [], True
+        )
+
+        removed = [call[0][0] for call in entity_registry.async_remove.call_args_list]
+        assert "sensor.strava_12345_gear_b111111_name" not in removed
+        assert "sensor.strava_12345_gear_b111111_distance" not in removed
+
+        enabled = [
+            call[0][0] for call in entity_registry.async_update_entity.call_args_list
+        ]
+        assert "sensor.strava_12345_gear_b111111_name" in enabled
+        assert "sensor.strava_12345_gear_b111111_distance" in enabled
+
+    @pytest.mark.asyncio
+    async def test_gear_entity_removed_when_gear_disabled(self, hass: HomeAssistant):
+        """New-format gear entities are removed when gear_enabled is False."""
+        new_name = MagicMock()
+        new_name.entity_id = "sensor.strava_12345_gear_b111111_name"
+        new_name.unique_id = "strava_12345_gear_b111111_name"
+
+        entity_registry, _ = await _run_gear_options_save(
+            hass, _make_config_entry(gear_enabled=False), [new_name], [], False
+        )
+
+        removed = [call[0][0] for call in entity_registry.async_remove.call_args_list]
+        assert "sensor.strava_12345_gear_b111111_name" in removed
+
+    @pytest.mark.asyncio
+    async def test_legacy_gear_device_removed_and_new_format_kept(
+        self, hass: HomeAssistant
+    ):
+        """Old index-based gear devices are removed; new gear_id devices are kept and enabled."""
+        legacy_device = MagicMock()
+        legacy_device.identifiers = {(DOMAIN, "strava_12345_gear_0")}
+        legacy_device.id = "legacy_gear_device"
+
+        new_device = MagicMock()
+        new_device.identifiers = {(DOMAIN, "strava_12345_gear_b111111")}
+        new_device.id = "new_gear_device"
+
+        _, device_registry = await _run_gear_options_save(
+            hass, _make_config_entry(), [], [legacy_device, new_device], True
+        )
+
+        removed_device_ids = [
+            call[0][0] for call in device_registry.async_remove_device.call_args_list
+        ]
+        assert "legacy_gear_device" in removed_device_ids
+        assert "new_gear_device" not in removed_device_ids
+
+        enabled_device_ids = [
+            call[0][0]
+            for call in device_registry.async_update_device.call_args_list
+            if call[1].get("disabled_by") is None
+        ]
+        assert "new_gear_device" in enabled_device_ids
+
+
+class TestRemoveLegacyGearEntries:
+    """Test the _remove_legacy_gear_entries helper called during async_setup_entry."""
+
+    @pytest.mark.asyncio
+    async def test_removes_legacy_entity_and_device(self, hass: HomeAssistant):
+        """Legacy index-based gear entities and devices are removed on integration setup."""
+        from custom_components.ha_strava import _remove_legacy_gear_entries
+        from custom_components.ha_strava.const import DOMAIN
+
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id="12345",
+            data={CONF_CLIENT_ID: "cid", CONF_CLIENT_SECRET: "csec"},
+            title="Strava: Test User",
+        )
+
+        legacy_entity = MagicMock()
+        legacy_entity.entity_id = "sensor.strava_12345_gear_0_name"
+        legacy_entity.unique_id = "strava_12345_gear_0_name"
+
+        keep_entity = MagicMock()
+        keep_entity.entity_id = "sensor.strava_12345_gear_b111111_name"
+        keep_entity.unique_id = "strava_12345_gear_b111111_name"
+
+        legacy_device = MagicMock()
+        legacy_device.identifiers = {(DOMAIN, "strava_12345_gear_0")}
+        legacy_device.id = "legacy_gear_device"
+
+        keep_device = MagicMock()
+        keep_device.identifiers = {(DOMAIN, "strava_12345_gear_b111111")}
+        keep_device.id = "new_gear_device"
+
+        mock_er = MagicMock()
+        mock_dr = MagicMock()
+
+        with patch(
+            "custom_components.ha_strava.er_async_get",
+            return_value=mock_er,
+        ), patch(
+            "custom_components.ha_strava.async_entries_for_config_entry",
+            return_value=[legacy_entity, keep_entity],
+        ), patch(
+            "custom_components.ha_strava.dr.async_get",
+            return_value=mock_dr,
+        ), patch(
+            "custom_components.ha_strava.dr.async_entries_for_config_entry",
+            return_value=[legacy_device, keep_device],
+        ):
+            _remove_legacy_gear_entries(hass, config_entry)
+
+        removed_entities = [call[0][0] for call in mock_er.async_remove.call_args_list]
+        assert "sensor.strava_12345_gear_0_name" in removed_entities
+        assert "sensor.strava_12345_gear_b111111_name" not in removed_entities
+
+        removed_devices = [
+            call[0][0] for call in mock_dr.async_remove_device.call_args_list
+        ]
+        assert "legacy_gear_device" in removed_devices
+        assert "new_gear_device" not in removed_devices
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_no_legacy_entries(self, hass: HomeAssistant):
+        """No removals occur when only new-format gear entities/devices exist."""
+        from custom_components.ha_strava import _remove_legacy_gear_entries
+        from custom_components.ha_strava.const import DOMAIN
+
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id="12345",
+            data={CONF_CLIENT_ID: "cid", CONF_CLIENT_SECRET: "csec"},
+            title="Strava: Test User",
+        )
+
+        new_entity = MagicMock()
+        new_entity.entity_id = "sensor.strava_12345_gear_b111111_name"
+        new_entity.unique_id = "strava_12345_gear_b111111_name"
+
+        new_device = MagicMock()
+        new_device.identifiers = {(DOMAIN, "strava_12345_gear_b111111")}
+        new_device.id = "new_gear_device"
+
+        mock_er = MagicMock()
+        mock_dr = MagicMock()
+
+        with patch(
+            "custom_components.ha_strava.er_async_get",
+            return_value=mock_er,
+        ), patch(
+            "custom_components.ha_strava.async_entries_for_config_entry",
+            return_value=[new_entity],
+        ), patch(
+            "custom_components.ha_strava.dr.async_get",
+            return_value=mock_dr,
+        ), patch(
+            "custom_components.ha_strava.dr.async_entries_for_config_entry",
+            return_value=[new_device],
+        ):
+            _remove_legacy_gear_entries(hass, config_entry)
+
+        mock_er.async_remove.assert_not_called()
+        mock_dr.async_remove_device.assert_not_called()


### PR DESCRIPTION
## Summary

- **fix: use stable gear ID instead of index for gear sensor unique_id (Issue #301)** — gear sensors were keyed by positional index in a distance-sorted list, causing sensors to display data for the wrong gear when ordering changed. Now uses Strava's stable gear ID (e.g. `b111111`).
- **fix: preserve distance unit override when options form is opened (Issue #289)** — the options form was resetting the distance unit override to the default value on first open instead of preserving the configured value.