### PR TITLE
fix: correct imperial pace unit conversion (Issue #183)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ pip install -r requirements_test.txt
 pre-commit install
 ```
 
+A devcontainer is available (`.devcontainer/`) for VS Code / Codespaces — it pre-installs all dependencies and wires up the HA test environment.
+
 ## Commands
 
 ```bash
@@ -25,6 +27,9 @@ pytest tests/custom_components/ha_strava/test_coordinator.py -v
 
 # Run a specific test
 pytest tests/custom_components/ha_strava/test_sensor.py::test_name -v
+
+# Coverage report
+pytest --cov=custom_components/ha_strava --cov-report=term-missing
 
 # Linting (also runs via pre-commit)
 black custom_components/ tests/
@@ -54,6 +59,14 @@ This is a Home Assistant custom component integrating Strava athlete data. One c
 | `camera.py`      | Photo carousel (up to 30 images, 24h cache)                                        |
 | `button.py`      | Manual refresh buttons per activity type                                           |
 | `const.py`       | All constants: OAuth URLs, 50+ activity types, config keys, sensor attributes      |
+
+**Sensor entity classes in `sensor.py`:**
+
+- `StravaStatsSensor` — per-activity attribute sensors (distance, time, elevation, HR, power, etc.)
+- `StravaSummaryStatsSensor` — recent/YTD/all-time aggregate stats per activity type
+- `StravaGearSensor` — gear name and distance per bike/shoe item
+
+Entity `unique_id` pattern: `strava_{athlete_id}_{activity_index}_{sensor_index}` (athlete ID ensures namespace isolation across multi-user setups).
 
 **Multi-user:**
 Each Strava account requires its own Strava API app (Strava limits one athlete per app). `unique_id` for each config entry = athlete ID. Webhook handler matches `owner_id` to route to the correct entry's coordinator.

--- a/custom_components/ha_strava/sensor.py
+++ b/custom_components/ha_strava/sensor.py
@@ -685,8 +685,9 @@ class StravaActivityTypeSensor(CoordinatorEntity, SensorEntity):
         is_metric = self._is_metric()
 
         if not is_metric:
-            pace = DistanceConverter.convert(
-                pace, UnitOfLength.KILOMETERS, UnitOfLength.MILES
+            # pace is s/km; multiply by km-per-mile to get s/mile
+            pace = pace * DistanceConverter.convert(
+                1, UnitOfLength.MILES, UnitOfLength.KILOMETERS
             )
 
         minutes = int(pace // 60)
@@ -1133,8 +1134,9 @@ class StravaActivityMetricSensor(StravaActivityAttributeSensor):
         is_metric = self._is_metric()
 
         if not is_metric:
-            pace = DistanceConverter.convert(
-                pace, UnitOfLength.KILOMETERS, UnitOfLength.MILES
+            # pace is s/km; multiply by km-per-mile to get s/mile
+            pace = pace * DistanceConverter.convert(
+                1, UnitOfLength.MILES, UnitOfLength.KILOMETERS
             )
 
         minutes = int(pace // 60)
@@ -1657,8 +1659,9 @@ class StravaRecentActivityMetricSensor(StravaRecentActivityAttributeSensor):
         is_metric = self._is_metric()
 
         if not is_metric:
-            pace = DistanceConverter.convert(
-                pace, UnitOfLength.KILOMETERS, UnitOfLength.MILES
+            # pace is s/km; multiply by km-per-mile to get s/mile
+            pace = pace * DistanceConverter.convert(
+                1, UnitOfLength.MILES, UnitOfLength.KILOMETERS
             )
 
         minutes = int(pace // 60)

--- a/tests/custom_components/ha_strava/test_activity_attribute_sensors.py
+++ b/tests/custom_components/ha_strava/test_activity_attribute_sensors.py
@@ -8,6 +8,7 @@ from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from custom_components.ha_strava.const import (
     CONF_DISTANCE_UNIT_OVERRIDE,
+    CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL,
     CONF_DISTANCE_UNIT_OVERRIDE_METRIC,
     CONF_SENSOR_CALORIES,
     CONF_SENSOR_DATE,
@@ -417,14 +418,21 @@ class TestStravaActivityMetricSensor:
         value = sensor.native_value
         assert value is None
 
-    def test_pace_calculation(self, mock_strava_activities):
-        """Test pace calculation."""
+    def test_pace_calculation_metric(self, mock_strava_activities):
+        """Test pace calculation in metric units.
+
+        Run fixture: distance=5000m, moving_time=1800s → 360 s/km = 6:00 min/km.
+        """
         coordinator = MagicMock()
         coordinator.data = {
             "activities": mock_strava_activities,
             "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
         }
         coordinator.entry = MagicMock()
+        coordinator.entry.options = {
+            CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_METRIC
+        }
+        coordinator.entry.data = {}
         mock_hass = MagicMock()
         mock_hass.config.units = METRIC_SYSTEM
         coordinator.hass = mock_hass
@@ -438,8 +446,39 @@ class TestStravaActivityMetricSensor:
         sensor.hass = mock_hass
 
         value = sensor.native_value
-        assert value is not None
-        assert ":" in value  # Should be in MM:SS format
+        assert value == "6:00 min/km"
+
+    def test_pace_calculation_imperial(self, mock_strava_activities):
+        """Test pace calculation in imperial units.
+
+        Run fixture: distance=5000m, moving_time=1800s → 360 s/km → 579 s/mi = 9:39 min/mi.
+        Previously bugged: multiplied by 0.621371 giving ~3:43 min/mi instead of ~9:39 min/mi.
+        """
+        coordinator = MagicMock()
+        coordinator.data = {
+            "activities": mock_strava_activities,
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+        coordinator.entry = MagicMock()
+        coordinator.entry.options = {
+            CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL
+        }
+        coordinator.entry.data = {}
+        mock_hass = MagicMock()
+        mock_hass.config.units = METRIC_SYSTEM
+        coordinator.hass = mock_hass
+
+        sensor = StravaActivityMetricSensor(
+            coordinator=coordinator,
+            activity_type="Run",
+            metric_type=CONF_SENSOR_PACE,
+            athlete_id="12345",
+        )
+        sensor.hass = mock_hass
+
+        value = sensor.native_value
+        # 360 s/km * 1.60934 km/mi = 579.36 s/mi = 9:39 min/mi
+        assert value == "9:39 min/mi"
 
     def test_speed_calculation(self, mock_strava_activities):
         """Test speed calculation."""


### PR DESCRIPTION
Fixes #183

## Problem

Imperial pace values were ~2.6× too fast (e.g. HA showed `3:59 min/mi` where Strava showed `10:27 min/mi`).

## Root cause

`_calculate_pace()` used `DistanceConverter.convert(pace, KILOMETERS, MILES)` which multiplies by `0.621371` — correct for converting a *distance* value, but wrong for *pace* (seconds per unit distance). Converting s/km → s/mi requires multiplying by `1.60934` (km per mile), not dividing.

## Fix

- Replace the incorrect `DistanceConverter.convert` call with `pace * DistanceConverter.convert(1, MILES, KILOMETERS)` in all three `_calculate_pace()` methods in `sensor.py`
- Replace the weak `test_pace_calculation` (only checked `":" in value`) with two precise tests asserting correct metric (`6:00 min/km`) and imperial (`9:39 min/mi`) values for a known distance/time pair