### PR TITLE
feat: expose pace as numeric value with formatted attributes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,13 @@ Uses `config_entry_oauth2_flow.OAuth2Session` with `LocalOAuth2Implementation`. 
 **Webhook lifecycle:**
 `renew_webhook_subscription()` in `__init__.py` calls Strava's webhook API to (re)register. Subscription ID persists in the config entry. On unload, the subscription is deleted.
 
+## Branching & PR Workflow
+
+- **Never commit directly to `main` or `develop`**
+- All changes must be on a dedicated feature/fix branch (`feat/`, `fix/`, `chore/`, `refactor/`, `docs/`)
+- PRs must target `develop` (not `main`) — `main` is only updated via release merges from `develop`
+- Branch naming: short, lowercase, hyphen-separated (e.g. `feat/pace-numeric-sensor`, `fix/gear-entity-id`)
+
 ## Code Standards
 
 - Max line length: 120 characters (Black, flake8, pylint all configured to this)

--- a/custom_components/ha_strava/sensor.py
+++ b/custom_components/ha_strava/sensor.py
@@ -674,28 +674,21 @@ class StravaActivityTypeSensor(CoordinatorEntity, SensorEntity):
         return attrs
 
     def _calculate_pace(self, activity):
-        """Calculate pace for the activity."""
+        """Calculate pace for the activity, returning decimal minutes."""
         distance = activity.get(CONF_SENSOR_DISTANCE, 0)
         moving_time = activity.get(CONF_SENSOR_MOVING_TIME, 0)
 
         if distance == 0 or moving_time == 0:
-            return "0:00"
+            return 0.0
 
         pace = moving_time / (distance / 1000)  # seconds per km
-        is_metric = self._is_metric()
-
-        if not is_metric:
+        if not self._is_metric():
             # pace is s/km; multiply by km-per-mile to get s/mile
             pace = pace * DistanceConverter.convert(
                 1, UnitOfLength.MILES, UnitOfLength.KILOMETERS
             )
 
-        minutes = int(pace // 60)
-        seconds = int(pace % 60)
-        unit = (
-            UNIT_PACE_MINUTES_PER_KILOMETER if is_metric else UNIT_PACE_MINUTES_PER_MILE
-        )
-        return f"{minutes}:{seconds:02} {unit}"
+        return round(pace / 60, 3)  # decimal minutes
 
     def _calculate_speed(self, activity):
         """Calculate speed for the activity."""
@@ -1086,6 +1079,13 @@ class StravaActivityMetricSensor(StravaActivityAttributeSensor):
     @property
     def native_unit_of_measurement(self):
         """Return the unit of measurement."""
+        if self._metric_type == CONF_SENSOR_PACE:
+            return (
+                UNIT_PACE_MINUTES_PER_KILOMETER
+                if self._is_metric()
+                else UNIT_PACE_MINUTES_PER_MILE
+            )
+
         config = CONF_ATTRIBUTE_SENSORS.get(self._metric_type, {})
         unit = config.get("unit")
 
@@ -1123,28 +1123,21 @@ class StravaActivityMetricSensor(StravaActivityAttributeSensor):
         return unit
 
     def _calculate_pace(self, activity):
-        """Calculate pace for the activity."""
+        """Calculate pace for the activity, returning decimal minutes."""
         distance = activity.get(CONF_SENSOR_DISTANCE, 0)
         moving_time = activity.get(CONF_SENSOR_MOVING_TIME, 0)
 
         if distance == 0 or moving_time == 0:
-            return "0:00"
+            return 0.0
 
         pace = moving_time / (distance / 1000)  # seconds per km
-        is_metric = self._is_metric()
-
-        if not is_metric:
+        if not self._is_metric():
             # pace is s/km; multiply by km-per-mile to get s/mile
             pace = pace * DistanceConverter.convert(
                 1, UnitOfLength.MILES, UnitOfLength.KILOMETERS
             )
 
-        minutes = int(pace // 60)
-        seconds = int(pace % 60)
-        unit = (
-            UNIT_PACE_MINUTES_PER_KILOMETER if is_metric else UNIT_PACE_MINUTES_PER_MILE
-        )
-        return f"{minutes}:{seconds:02} {unit}"
+        return round(pace / 60, 3)  # decimal minutes
 
     def _calculate_speed(self, activity):
         """Calculate speed for the activity."""
@@ -1183,6 +1176,20 @@ class StravaActivityMetricSensor(StravaActivityAttributeSensor):
                 attributes["formatted_time"] = format_seconds_to_human_readable(
                     time_value
                 )
+
+        # Add formatted pace string for pace sensors
+        if self._metric_type == CONF_SENSOR_PACE:
+            pace_val = self.native_value
+            if pace_val:
+                mins = int(pace_val)
+                secs = int(round((pace_val - mins) * 60))
+                unit = (
+                    UNIT_PACE_MINUTES_PER_KILOMETER
+                    if self._is_metric()
+                    else UNIT_PACE_MINUTES_PER_MILE
+                )
+                attributes["formatted_pace"] = f"{mins}:{secs:02d} {unit}"
+                attributes["pace"] = f"{mins}:{secs:02d}"
 
         return attributes
 
@@ -1612,6 +1619,13 @@ class StravaRecentActivityMetricSensor(StravaRecentActivityAttributeSensor):
     @property
     def native_unit_of_measurement(self):
         """Return the unit of measurement."""
+        if self._metric_type == CONF_SENSOR_PACE:
+            return (
+                UNIT_PACE_MINUTES_PER_KILOMETER
+                if self._is_metric()
+                else UNIT_PACE_MINUTES_PER_MILE
+            )
+
         config = CONF_ATTRIBUTE_SENSORS.get(self._metric_type, {})
         unit = config.get("unit")
 
@@ -1648,28 +1662,21 @@ class StravaRecentActivityMetricSensor(StravaRecentActivityAttributeSensor):
         return unit
 
     def _calculate_pace(self, activity):
-        """Calculate pace for the activity."""
+        """Calculate pace for the activity, returning decimal minutes."""
         distance = activity.get(CONF_SENSOR_DISTANCE, 0)
         moving_time = activity.get(CONF_SENSOR_MOVING_TIME, 0)
 
         if distance == 0 or moving_time == 0:
-            return "0:00"
+            return 0.0
 
-        pace = moving_time / (distance / 1000)
-        is_metric = self._is_metric()
-
-        if not is_metric:
+        pace = moving_time / (distance / 1000)  # seconds per km
+        if not self._is_metric():
             # pace is s/km; multiply by km-per-mile to get s/mile
             pace = pace * DistanceConverter.convert(
                 1, UnitOfLength.MILES, UnitOfLength.KILOMETERS
             )
 
-        minutes = int(pace // 60)
-        seconds = int(pace % 60)
-        unit = (
-            UNIT_PACE_MINUTES_PER_KILOMETER if is_metric else UNIT_PACE_MINUTES_PER_MILE
-        )
-        return f"{minutes}:{seconds:02} {unit}"
+        return round(pace / 60, 3)  # decimal minutes
 
     def _calculate_speed(self, activity):
         """Calculate speed for the activity."""
@@ -1708,6 +1715,20 @@ class StravaRecentActivityMetricSensor(StravaRecentActivityAttributeSensor):
                 attributes["formatted_time"] = format_seconds_to_human_readable(
                     time_value
                 )
+
+        # Add formatted pace string for pace sensors
+        if self._metric_type == CONF_SENSOR_PACE:
+            pace_val = self.native_value
+            if pace_val:
+                mins = int(pace_val)
+                secs = int(round((pace_val - mins) * 60))
+                unit = (
+                    UNIT_PACE_MINUTES_PER_KILOMETER
+                    if self._is_metric()
+                    else UNIT_PACE_MINUTES_PER_MILE
+                )
+                attributes["formatted_pace"] = f"{mins}:{secs:02d} {unit}"
+                attributes["pace"] = f"{mins}:{secs:02d}"
 
         return attributes
 

--- a/tests/custom_components/ha_strava/test_activity_attribute_sensors.py
+++ b/tests/custom_components/ha_strava/test_activity_attribute_sensors.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+import pytest
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import UnitOfLength, UnitOfTime
 from homeassistant.util.unit_system import METRIC_SYSTEM
@@ -421,7 +422,7 @@ class TestStravaActivityMetricSensor:
     def test_pace_calculation_metric(self, mock_strava_activities):
         """Test pace calculation in metric units.
 
-        Run fixture: distance=5000m, moving_time=1800s → 360 s/km = 6:00 min/km.
+        Run fixture: distance=5000m, moving_time=1800s → 360 s/km = 6.0 min/km.
         """
         coordinator = MagicMock()
         coordinator.data = {
@@ -446,12 +447,16 @@ class TestStravaActivityMetricSensor:
         sensor.hass = mock_hass
 
         value = sensor.native_value
-        assert value == "6:00 min/km"
+        assert value == 6.0
+        assert sensor.native_unit_of_measurement == "min/km"
+        attrs = sensor.extra_state_attributes
+        assert attrs["formatted_pace"] == "6:00 min/km"
+        assert attrs["pace"] == "6:00"
 
     def test_pace_calculation_imperial(self, mock_strava_activities):
         """Test pace calculation in imperial units.
 
-        Run fixture: distance=5000m, moving_time=1800s → 360 s/km → 579 s/mi = 9:39 min/mi.
+        Run fixture: distance=5000m, moving_time=1800s → 360 s/km → 579.36 s/mi = 9.656 min/mi.
         Previously bugged: multiplied by 0.621371 giving ~3:43 min/mi instead of ~9:39 min/mi.
         """
         coordinator = MagicMock()
@@ -477,8 +482,12 @@ class TestStravaActivityMetricSensor:
         sensor.hass = mock_hass
 
         value = sensor.native_value
-        # 360 s/km * 1.60934 km/mi = 579.36 s/mi = 9:39 min/mi
-        assert value == "9:39 min/mi"
+        # 360 s/km * 1.60934 km/mi = 579.36 s/mi = 9.656 min/mi
+        assert value == pytest.approx(9.656, abs=0.01)
+        assert sensor.native_unit_of_measurement == "min/mi"
+        attrs = sensor.extra_state_attributes
+        assert attrs["formatted_pace"] == "9:39 min/mi"
+        assert attrs["pace"] == "9:39"
 
     def test_speed_calculation(self, mock_strava_activities):
         """Test speed calculation."""


### PR DESCRIPTION
## Summary
- Pace sensors now return a numeric `native_value` (decimal minutes, e.g. `6.0`) with `native_unit_of_measurement` set to `min/km` or `min/mi` — enabling history graphs and numeric comparisons
- Two extra attributes added to all pace sensors:
  - `formatted_pace`: `"12:32 min/mi"` — MM:SS with unit, for Lovelace display
  - `pace`: `"12:32"` — MM:SS only, for use in templates or automations

## Breaking change
The sensor state was previously a string (`"12:32 min/mi"`). It is now a float (`12.533`). Automations or templates reading the old string state should switch to the `formatted_pace` or `pace` attribute.

Closes #183 (follow-up comment from ScottG489)