### PR TITLE
chore: bump version to 4.2.1

### DIFF
--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.2.0"
+  "version": "4.2.1"
 }


### PR DESCRIPTION
## Summary
- Bump manifest version to 4.2.1 for pace numeric sensor changes (#316)