### PR TITLE
feat: pace numeric sensors, update_activity service, pace fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ pip install -r requirements_test.txt
 pre-commit install
 ```
 
+A devcontainer is available (`.devcontainer/`) for VS Code / Codespaces — it pre-installs all dependencies and wires up the HA test environment.
+
 ## Commands
 
 ```bash
@@ -25,6 +27,9 @@ pytest tests/custom_components/ha_strava/test_coordinator.py -v
 
 # Run a specific test
 pytest tests/custom_components/ha_strava/test_sensor.py::test_name -v
+
+# Coverage report
+pytest --cov=custom_components/ha_strava --cov-report=term-missing
 
 # Linting (also runs via pre-commit)
 black custom_components/ tests/
@@ -54,6 +59,14 @@ This is a Home Assistant custom component integrating Strava athlete data. One c
 | `camera.py`      | Photo carousel (up to 30 images, 24h cache)                                        |
 | `button.py`      | Manual refresh buttons per activity type                                           |
 | `const.py`       | All constants: OAuth URLs, 50+ activity types, config keys, sensor attributes      |
+
+**Sensor entity classes in `sensor.py`:**
+
+- `StravaStatsSensor` — per-activity attribute sensors (distance, time, elevation, HR, power, etc.)
+- `StravaSummaryStatsSensor` — recent/YTD/all-time aggregate stats per activity type
+- `StravaGearSensor` — gear name and distance per bike/shoe item
+
+Entity `unique_id` pattern: `strava_{athlete_id}_{activity_index}_{sensor_index}` (athlete ID ensures namespace isolation across multi-user setups).
 
 **Multi-user:**
 Each Strava account requires its own Strava API app (Strava limits one athlete per app). `unique_id` for each config entry = athlete ID. Webhook handler matches `owner_id` to route to the correct entry's coordinator.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,13 @@ Uses `config_entry_oauth2_flow.OAuth2Session` with `LocalOAuth2Implementation`. 
 **Webhook lifecycle:**
 `renew_webhook_subscription()` in `__init__.py` calls Strava's webhook API to (re)register. Subscription ID persists in the config entry. On unload, the subscription is deleted.
 
+## Branching & PR Workflow
+
+- **Never commit directly to `main` or `develop`**
+- All changes must be on a dedicated feature/fix branch (`feat/`, `fix/`, `chore/`, `refactor/`, `docs/`)
+- PRs must target `develop` (not `main`) — `main` is only updated via release merges from `develop`
+- Branch naming: short, lowercase, hyphen-separated (e.g. `feat/pace-numeric-sensor`, `fix/gear-entity-id`)
+
 ## Code Standards
 
 - Max line length: 120 characters (Black, flake8, pylint all configured to this)

--- a/custom_components/ha_strava/__init__.py
+++ b/custom_components/ha_strava/__init__.py
@@ -8,17 +8,25 @@ from urllib.parse import urlparse
 import aiohttp
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.device_registry as dr
+import voluptuous as vol
 from aiohttp.web import Request, Response, json_response
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_WEBHOOK_ID
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_registry import async_entries_for_config_entry
 from homeassistant.helpers.entity_registry import async_get as er_async_get
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 
-from .const import CONF_CALLBACK_URL, DOMAIN, WEBHOOK_SUBSCRIPTION_URL
+from .const import (
+    CONF_CALLBACK_URL,
+    DOMAIN,
+    SERVICE_UPDATE_ACTIVITY,
+    SUPPORTED_ACTIVITY_TYPES,
+    WEBHOOK_SUBSCRIPTION_URL,
+)
 from .coordinator import StravaDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -309,6 +317,67 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Register the update_activity service once per domain (not per entry)
+    if not hass.services.has_service(DOMAIN, SERVICE_UPDATE_ACTIVITY):
+
+        async def async_handle_update_activity(call: ServiceCall) -> None:
+            """Handle the update_activity service call."""
+            activity_id = call.data["activity_id"]
+
+            fields = {}
+            for key in (
+                "sport_type",
+                "name",
+                "description",
+                "gear_id",
+                "trainer",
+                "commute",
+                "hide_from_home",
+                "private_note",
+            ):
+                if key in call.data:
+                    fields[key] = call.data[key]
+
+            # Find the coordinator that owns this activity
+            target_coordinator = None
+            for coord in hass.data[DOMAIN].values():
+                current_data = coord.data or {}
+                for activity in current_data.get("activities") or []:
+                    if str(activity.get("id")) == str(activity_id):
+                        target_coordinator = coord
+                        break
+                if target_coordinator:
+                    break
+
+            if target_coordinator is None:
+                raise ServiceValidationError(
+                    "Activity not found in any tracked athlete's recent activities. "
+                    "Trigger a refresh first or check the activity ID."
+                )
+
+            await target_coordinator.async_update_activity(activity_id, **fields)
+
+        _VALID_SPORT_TYPES = [t for t in SUPPORTED_ACTIVITY_TYPES if t != "Other"]
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_UPDATE_ACTIVITY,
+            async_handle_update_activity,
+            schema=vol.Schema(
+                {
+                    vol.Required("activity_id"): vol.Coerce(str),
+                    vol.Optional("sport_type"): vol.In(_VALID_SPORT_TYPES),
+                    vol.Optional("name"): str,
+                    vol.Optional("description"): str,
+                    vol.Optional("gear_id"): str,
+                    vol.Optional("trainer"): bool,
+                    vol.Optional("commute"): bool,
+                    vol.Optional("hide_from_home"): bool,
+                    vol.Optional("private_note"): str,
+                }
+            ),
+        )
+
     # Register update listener for options changes
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
@@ -337,6 +406,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
                 _LOGGER.error(f"Failed to delete webhook subscription: {err}")
 
         hass.data[DOMAIN].pop(entry.entry_id)
+
+        # Remove the service if no more entries remain
+        if not hass.data[DOMAIN]:
+            hass.services.async_remove(DOMAIN, SERVICE_UPDATE_ACTIVITY)
 
     return unload_ok
 

--- a/custom_components/ha_strava/config_flow.py
+++ b/custom_components/ha_strava/config_flow.py
@@ -42,6 +42,7 @@ from .const import (
     DEFAULT_ACTIVITY_TYPES,
     DOMAIN,
     OAUTH2_AUTHORIZE,
+    OAUTH2_SCOPES,
     OAUTH2_TOKEN,
     SUPPORTED_ACTIVITY_TYPES,
     normalize_activity_type,
@@ -526,7 +527,7 @@ class OAuth2FlowHandler(
     def extra_authorize_data(self) -> dict:
         """Extra data that needs to be appended to the authorize url."""
         return {
-            "scope": "activity:read_all,profile:read_all",
+            "scope": OAUTH2_SCOPES,
             "approval_prompt": "force",
             "response_type": "code",
         }

--- a/custom_components/ha_strava/const.py
+++ b/custom_components/ha_strava/const.py
@@ -9,6 +9,10 @@ CONFIG_ENTRY_TITLE = "Strava"
 AUTH_CALLBACK_PATH = "/auth/external/callback"
 OAUTH2_AUTHORIZE = "https://www.strava.com/oauth/authorize"
 OAUTH2_TOKEN = "https://www.strava.com/oauth/token"
+OAUTH2_SCOPES = "activity:read_all,profile:read_all,activity:write"
+
+# Services
+SERVICE_UPDATE_ACTIVITY = "update_activity"
 
 # Camera Config
 CONF_PHOTOS = "conf_photos"

--- a/custom_components/ha_strava/coordinator.py
+++ b/custom_components/ha_strava/coordinator.py
@@ -16,7 +16,6 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import (
     CONF_ACTIVITY_TYPE_OTHER,
     CONF_ACTIVITY_TYPES_TO_TRACK,
-    SUPPORTED_ACTIVITY_TYPES,
     CONF_API_RETRY_BASE_DELAY_SECONDS,
     CONF_API_RETRY_MAX_ATTEMPTS,
     CONF_ATTR_COMMUTE,
@@ -65,6 +64,7 @@ from .const import (
     DOMAIN,
     OAUTH2_AUTHORIZE,
     OAUTH2_TOKEN,
+    SUPPORTED_ACTIVITY_TYPES,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -518,6 +518,130 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.error(f"Error fetching gear {gear_id}: {e}")
             return {}
 
+    async def async_update_activity(
+        self, activity_id: int | str, **fields: dict
+    ) -> None:
+        """Update an activity via the Strava API and refresh local state."""
+        try:
+            await self.oauth_session.async_ensure_token_valid()
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Error ensuring token is valid: {err}")
+            raise UpdateFailed(f"Authentication error: {err}") from err
+
+        url = f"https://www.strava.com/api/v3/activities/{activity_id}"
+        payload = {k: v for k, v in fields.items() if v is not None}
+        updated_activity = None
+        last_exception = None
+
+        for attempt in range(CONF_API_RETRY_MAX_ATTEMPTS):
+            try:
+                response = await self.oauth_session.async_request(
+                    method="PUT",
+                    url=url,
+                    json=payload,
+                )
+
+                if response.status == 429:
+                    retry_after = int(
+                        response.headers.get(
+                            "Retry-After",
+                            CONF_API_RETRY_BASE_DELAY_SECONDS * (2**attempt),
+                        )
+                    )
+                    if attempt < CONF_API_RETRY_MAX_ATTEMPTS - 1:
+                        _LOGGER.warning(
+                            f"Rate limit hit updating activity {activity_id}, "
+                            f"retrying after {retry_after} seconds "
+                            f"(attempt {attempt + 1}/{CONF_API_RETRY_MAX_ATTEMPTS})"
+                        )
+                        await asyncio.sleep(retry_after)
+                        continue
+                    raise UpdateFailed(
+                        f"Rate limit exceeded updating activity {activity_id} "
+                        f"after {CONF_API_RETRY_MAX_ATTEMPTS} attempts"
+                    )
+
+                response.raise_for_status()
+                updated_activity = await response.json()
+                break
+
+            except aiohttp.ClientResponseError as err:
+                if err.status in (401, 403):
+                    raise ConfigEntryAuthFailed(
+                        f"Insufficient permissions to update activity {activity_id}. "
+                        "Please re-authenticate the integration."
+                    ) from err
+                if err.status == 429 and attempt < CONF_API_RETRY_MAX_ATTEMPTS - 1:
+                    retry_after = int(
+                        err.headers.get(
+                            "Retry-After",
+                            CONF_API_RETRY_BASE_DELAY_SECONDS * (2**attempt),
+                        )
+                    )
+                    _LOGGER.warning(
+                        f"Rate limit hit updating activity {activity_id}, "
+                        f"retrying after {retry_after} seconds "
+                        f"(attempt {attempt + 1}/{CONF_API_RETRY_MAX_ATTEMPTS})"
+                    )
+                    await asyncio.sleep(retry_after)
+                    last_exception = err
+                    continue
+                raise UpdateFailed(
+                    f"Error updating activity {activity_id}: {err}"
+                ) from err
+            except aiohttp.ClientError as err:
+                last_exception = err
+                if attempt < CONF_API_RETRY_MAX_ATTEMPTS - 1:
+                    await asyncio.sleep(
+                        CONF_API_RETRY_BASE_DELAY_SECONDS * (2**attempt)
+                    )
+                    continue
+                raise UpdateFailed(
+                    f"Network error updating activity {activity_id}: {err}"
+                ) from err
+
+        if updated_activity is None:
+            if last_exception:
+                raise last_exception
+            raise UpdateFailed(
+                f"Failed to update activity {activity_id} "
+                f"after {CONF_API_RETRY_MAX_ATTEMPTS} attempts"
+            )
+
+        _LOGGER.info(f"Successfully updated activity {activity_id}: {payload}")
+
+        processed = self._sensor_activity(
+            updated_activity,
+            updated_activity,
+            sport_type=updated_activity.get("sport_type"),
+        )
+        current_data = self.data or {}
+        current_activities = current_data.get("activities") or []
+        new_activities = []
+        updated = False
+
+        for existing in current_activities:
+            if existing.get(CONF_SENSOR_ID) == processed.get(CONF_SENSOR_ID):
+                new_activities.append(processed)
+                updated = True
+            else:
+                new_activities.append(existing)
+
+        if not updated:
+            new_activities.append(processed)
+
+        num_recent_activities = self.entry.options.get(
+            CONF_NUM_RECENT_ACTIVITIES, CONF_NUM_RECENT_ACTIVITIES_DEFAULT
+        )
+        sorted_activities = sorted(
+            new_activities,
+            key=lambda a: a[CONF_SENSOR_DATE],
+            reverse=True,
+        )
+        limited_activities = sorted_activities[:num_recent_activities]
+
+        self.async_set_updated_data({**current_data, "activities": limited_activities})
+
     async def async_refresh_activity(self, activity_id: int) -> None:
         if not activity_id:
             return
@@ -585,7 +709,9 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
 
         self.async_set_updated_data(new_data)
 
-    def _sensor_activity(self, activity: dict, activity_dto: dict, sport_type: str = None) -> dict:
+    def _sensor_activity(
+        self, activity: dict, activity_dto: dict, sport_type: str = None
+    ) -> dict:
         # Extract device information
         device_name = "Unknown"
         device_type = "Unknown"
@@ -635,7 +761,9 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
         source = activity_dto if activity_dto else activity
-        effective_sport_type = sport_type or (source.get("sport_type") or source.get("type"))
+        effective_sport_type = sport_type or (
+            source.get("sport_type") or source.get("type")
+        )
 
         return {
             CONF_SENSOR_ID: activity.get("id"),

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.1.8"
+  "version": "4.1.9"
 }

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.1.9"
+  "version": "4.2.0"
 }

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.2.0"
+  "version": "4.2.1"
 }

--- a/custom_components/ha_strava/sensor.py
+++ b/custom_components/ha_strava/sensor.py
@@ -685,8 +685,9 @@ class StravaActivityTypeSensor(CoordinatorEntity, SensorEntity):
         is_metric = self._is_metric()
 
         if not is_metric:
-            pace = DistanceConverter.convert(
-                pace, UnitOfLength.KILOMETERS, UnitOfLength.MILES
+            # pace is s/km; multiply by km-per-mile to get s/mile
+            pace = pace * DistanceConverter.convert(
+                1, UnitOfLength.MILES, UnitOfLength.KILOMETERS
             )
 
         minutes = int(pace // 60)
@@ -1133,8 +1134,9 @@ class StravaActivityMetricSensor(StravaActivityAttributeSensor):
         is_metric = self._is_metric()
 
         if not is_metric:
-            pace = DistanceConverter.convert(
-                pace, UnitOfLength.KILOMETERS, UnitOfLength.MILES
+            # pace is s/km; multiply by km-per-mile to get s/mile
+            pace = pace * DistanceConverter.convert(
+                1, UnitOfLength.MILES, UnitOfLength.KILOMETERS
             )
 
         minutes = int(pace // 60)
@@ -1657,8 +1659,9 @@ class StravaRecentActivityMetricSensor(StravaRecentActivityAttributeSensor):
         is_metric = self._is_metric()
 
         if not is_metric:
-            pace = DistanceConverter.convert(
-                pace, UnitOfLength.KILOMETERS, UnitOfLength.MILES
+            # pace is s/km; multiply by km-per-mile to get s/mile
+            pace = pace * DistanceConverter.convert(
+                1, UnitOfLength.MILES, UnitOfLength.KILOMETERS
             )
 
         minutes = int(pace // 60)

--- a/custom_components/ha_strava/sensor.py
+++ b/custom_components/ha_strava/sensor.py
@@ -674,28 +674,21 @@ class StravaActivityTypeSensor(CoordinatorEntity, SensorEntity):
         return attrs
 
     def _calculate_pace(self, activity):
-        """Calculate pace for the activity."""
+        """Calculate pace for the activity, returning decimal minutes."""
         distance = activity.get(CONF_SENSOR_DISTANCE, 0)
         moving_time = activity.get(CONF_SENSOR_MOVING_TIME, 0)
 
         if distance == 0 or moving_time == 0:
-            return "0:00"
+            return 0.0
 
         pace = moving_time / (distance / 1000)  # seconds per km
-        is_metric = self._is_metric()
-
-        if not is_metric:
+        if not self._is_metric():
             # pace is s/km; multiply by km-per-mile to get s/mile
             pace = pace * DistanceConverter.convert(
                 1, UnitOfLength.MILES, UnitOfLength.KILOMETERS
             )
 
-        minutes = int(pace // 60)
-        seconds = int(pace % 60)
-        unit = (
-            UNIT_PACE_MINUTES_PER_KILOMETER if is_metric else UNIT_PACE_MINUTES_PER_MILE
-        )
-        return f"{minutes}:{seconds:02} {unit}"
+        return round(pace / 60, 3)  # decimal minutes
 
     def _calculate_speed(self, activity):
         """Calculate speed for the activity."""
@@ -1086,6 +1079,13 @@ class StravaActivityMetricSensor(StravaActivityAttributeSensor):
     @property
     def native_unit_of_measurement(self):
         """Return the unit of measurement."""
+        if self._metric_type == CONF_SENSOR_PACE:
+            return (
+                UNIT_PACE_MINUTES_PER_KILOMETER
+                if self._is_metric()
+                else UNIT_PACE_MINUTES_PER_MILE
+            )
+
         config = CONF_ATTRIBUTE_SENSORS.get(self._metric_type, {})
         unit = config.get("unit")
 
@@ -1123,28 +1123,21 @@ class StravaActivityMetricSensor(StravaActivityAttributeSensor):
         return unit
 
     def _calculate_pace(self, activity):
-        """Calculate pace for the activity."""
+        """Calculate pace for the activity, returning decimal minutes."""
         distance = activity.get(CONF_SENSOR_DISTANCE, 0)
         moving_time = activity.get(CONF_SENSOR_MOVING_TIME, 0)
 
         if distance == 0 or moving_time == 0:
-            return "0:00"
+            return 0.0
 
         pace = moving_time / (distance / 1000)  # seconds per km
-        is_metric = self._is_metric()
-
-        if not is_metric:
+        if not self._is_metric():
             # pace is s/km; multiply by km-per-mile to get s/mile
             pace = pace * DistanceConverter.convert(
                 1, UnitOfLength.MILES, UnitOfLength.KILOMETERS
             )
 
-        minutes = int(pace // 60)
-        seconds = int(pace % 60)
-        unit = (
-            UNIT_PACE_MINUTES_PER_KILOMETER if is_metric else UNIT_PACE_MINUTES_PER_MILE
-        )
-        return f"{minutes}:{seconds:02} {unit}"
+        return round(pace / 60, 3)  # decimal minutes
 
     def _calculate_speed(self, activity):
         """Calculate speed for the activity."""
@@ -1183,6 +1176,20 @@ class StravaActivityMetricSensor(StravaActivityAttributeSensor):
                 attributes["formatted_time"] = format_seconds_to_human_readable(
                     time_value
                 )
+
+        # Add formatted pace string for pace sensors
+        if self._metric_type == CONF_SENSOR_PACE:
+            pace_val = self.native_value
+            if pace_val:
+                mins = int(pace_val)
+                secs = int(round((pace_val - mins) * 60))
+                unit = (
+                    UNIT_PACE_MINUTES_PER_KILOMETER
+                    if self._is_metric()
+                    else UNIT_PACE_MINUTES_PER_MILE
+                )
+                attributes["formatted_pace"] = f"{mins}:{secs:02d} {unit}"
+                attributes["pace"] = f"{mins}:{secs:02d}"
 
         return attributes
 
@@ -1612,6 +1619,13 @@ class StravaRecentActivityMetricSensor(StravaRecentActivityAttributeSensor):
     @property
     def native_unit_of_measurement(self):
         """Return the unit of measurement."""
+        if self._metric_type == CONF_SENSOR_PACE:
+            return (
+                UNIT_PACE_MINUTES_PER_KILOMETER
+                if self._is_metric()
+                else UNIT_PACE_MINUTES_PER_MILE
+            )
+
         config = CONF_ATTRIBUTE_SENSORS.get(self._metric_type, {})
         unit = config.get("unit")
 
@@ -1648,28 +1662,21 @@ class StravaRecentActivityMetricSensor(StravaRecentActivityAttributeSensor):
         return unit
 
     def _calculate_pace(self, activity):
-        """Calculate pace for the activity."""
+        """Calculate pace for the activity, returning decimal minutes."""
         distance = activity.get(CONF_SENSOR_DISTANCE, 0)
         moving_time = activity.get(CONF_SENSOR_MOVING_TIME, 0)
 
         if distance == 0 or moving_time == 0:
-            return "0:00"
+            return 0.0
 
-        pace = moving_time / (distance / 1000)
-        is_metric = self._is_metric()
-
-        if not is_metric:
+        pace = moving_time / (distance / 1000)  # seconds per km
+        if not self._is_metric():
             # pace is s/km; multiply by km-per-mile to get s/mile
             pace = pace * DistanceConverter.convert(
                 1, UnitOfLength.MILES, UnitOfLength.KILOMETERS
             )
 
-        minutes = int(pace // 60)
-        seconds = int(pace % 60)
-        unit = (
-            UNIT_PACE_MINUTES_PER_KILOMETER if is_metric else UNIT_PACE_MINUTES_PER_MILE
-        )
-        return f"{minutes}:{seconds:02} {unit}"
+        return round(pace / 60, 3)  # decimal minutes
 
     def _calculate_speed(self, activity):
         """Calculate speed for the activity."""
@@ -1708,6 +1715,20 @@ class StravaRecentActivityMetricSensor(StravaRecentActivityAttributeSensor):
                 attributes["formatted_time"] = format_seconds_to_human_readable(
                     time_value
                 )
+
+        # Add formatted pace string for pace sensors
+        if self._metric_type == CONF_SENSOR_PACE:
+            pace_val = self.native_value
+            if pace_val:
+                mins = int(pace_val)
+                secs = int(round((pace_val - mins) * 60))
+                unit = (
+                    UNIT_PACE_MINUTES_PER_KILOMETER
+                    if self._is_metric()
+                    else UNIT_PACE_MINUTES_PER_MILE
+                )
+                attributes["formatted_pace"] = f"{mins}:{secs:02d} {unit}"
+                attributes["pace"] = f"{mins}:{secs:02d}"
 
         return attributes
 

--- a/custom_components/ha_strava/services.yaml
+++ b/custom_components/ha_strava/services.yaml
@@ -1,0 +1,125 @@
+update_activity:
+  name: Update Activity
+  description: >-
+    Update an existing Strava activity. Supports modifiable fields from the Strava
+    UpdatableActivity model. Requires the `activity:write` OAuth scope. If missing,
+    re-authenticate the integration when prompted (you do not need to remove and re-add it).
+  fields:
+    activity_id:
+      name: Activity ID
+      description: The numeric Strava activity ID to update.
+      required: true
+      example: "1234567890"
+      selector:
+        text:
+    sport_type:
+      name: Sport Type
+      description: The sport type for the activity.
+      required: false
+      example: Run
+      selector:
+        select:
+          options:
+            - AlpineSki
+            - BackcountrySki
+            - Badminton
+            - Basketball
+            - Canoeing
+            - Cricket
+            - Crossfit
+            - Dance
+            - EBikeRide
+            - Elliptical
+            - EMountainBikeRide
+            - Golf
+            - GravelRide
+            - Handcycle
+            - HighIntensityIntervalTraining
+            - Hike
+            - IceSkate
+            - InlineSkate
+            - Kayaking
+            - Kitesurf
+            - MountainBikeRide
+            - NordicSki
+            - Padel
+            - Pickleball
+            - Pilates
+            - Racquetball
+            - Ride
+            - RockClimbing
+            - RollerSki
+            - Rowing
+            - Run
+            - Sail
+            - Skateboard
+            - Snowboard
+            - Snowshoe
+            - Soccer
+            - Squash
+            - StairStepper
+            - StandUpPaddling
+            - Surfing
+            - Swim
+            - TableTennis
+            - Tennis
+            - TrailRun
+            - Velomobile
+            - VirtualRide
+            - VirtualRow
+            - VirtualRun
+            - Volleyball
+            - Walk
+            - WeightTraining
+            - Wheelchair
+            - Windsurf
+            - Workout
+            - Yoga
+    name:
+      name: Name
+      description: The name of the activity.
+      required: false
+      example: "Morning Run"
+      selector:
+        text:
+    description:
+      name: Description
+      description: The description of the activity.
+      required: false
+      selector:
+        text:
+          multiline: true
+    gear_id:
+      name: Gear ID
+      description: The Strava gear ID to associate with the activity.
+      required: false
+      example: "b1234567"
+      selector:
+        text:
+    trainer:
+      name: Trainer
+      description: Whether the activity was performed on a trainer.
+      required: false
+      selector:
+        boolean:
+    commute:
+      name: Commute
+      description: Whether the activity is a commute.
+      required: false
+      selector:
+        boolean:
+    hide_from_home:
+      name: Hide from Home
+      description: Whether to hide the activity from the Strava home feed.
+      required: false
+      selector:
+        boolean:
+    private_note:
+      name: Private Note
+      description: >-
+        A private note visible only to the athlete. Not in Strava's official
+        UpdatableActivity docs but accepted by the API.
+      required: false
+      selector:
+        text:
+          multiline: true

--- a/tests/custom_components/ha_strava/test_activity_attribute_sensors.py
+++ b/tests/custom_components/ha_strava/test_activity_attribute_sensors.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+import pytest
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import UnitOfLength, UnitOfTime
 from homeassistant.util.unit_system import METRIC_SYSTEM
@@ -421,7 +422,7 @@ class TestStravaActivityMetricSensor:
     def test_pace_calculation_metric(self, mock_strava_activities):
         """Test pace calculation in metric units.
 
-        Run fixture: distance=5000m, moving_time=1800s → 360 s/km = 6:00 min/km.
+        Run fixture: distance=5000m, moving_time=1800s → 360 s/km = 6.0 min/km.
         """
         coordinator = MagicMock()
         coordinator.data = {
@@ -446,12 +447,16 @@ class TestStravaActivityMetricSensor:
         sensor.hass = mock_hass
 
         value = sensor.native_value
-        assert value == "6:00 min/km"
+        assert value == 6.0
+        assert sensor.native_unit_of_measurement == "min/km"
+        attrs = sensor.extra_state_attributes
+        assert attrs["formatted_pace"] == "6:00 min/km"
+        assert attrs["pace"] == "6:00"
 
     def test_pace_calculation_imperial(self, mock_strava_activities):
         """Test pace calculation in imperial units.
 
-        Run fixture: distance=5000m, moving_time=1800s → 360 s/km → 579 s/mi = 9:39 min/mi.
+        Run fixture: distance=5000m, moving_time=1800s → 360 s/km → 579.36 s/mi = 9.656 min/mi.
         Previously bugged: multiplied by 0.621371 giving ~3:43 min/mi instead of ~9:39 min/mi.
         """
         coordinator = MagicMock()
@@ -477,8 +482,12 @@ class TestStravaActivityMetricSensor:
         sensor.hass = mock_hass
 
         value = sensor.native_value
-        # 360 s/km * 1.60934 km/mi = 579.36 s/mi = 9:39 min/mi
-        assert value == "9:39 min/mi"
+        # 360 s/km * 1.60934 km/mi = 579.36 s/mi = 9.656 min/mi
+        assert value == pytest.approx(9.656, abs=0.01)
+        assert sensor.native_unit_of_measurement == "min/mi"
+        attrs = sensor.extra_state_attributes
+        assert attrs["formatted_pace"] == "9:39 min/mi"
+        assert attrs["pace"] == "9:39"
 
     def test_speed_calculation(self, mock_strava_activities):
         """Test speed calculation."""

--- a/tests/custom_components/ha_strava/test_activity_attribute_sensors.py
+++ b/tests/custom_components/ha_strava/test_activity_attribute_sensors.py
@@ -8,6 +8,7 @@ from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from custom_components.ha_strava.const import (
     CONF_DISTANCE_UNIT_OVERRIDE,
+    CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL,
     CONF_DISTANCE_UNIT_OVERRIDE_METRIC,
     CONF_SENSOR_CALORIES,
     CONF_SENSOR_DATE,
@@ -417,14 +418,21 @@ class TestStravaActivityMetricSensor:
         value = sensor.native_value
         assert value is None
 
-    def test_pace_calculation(self, mock_strava_activities):
-        """Test pace calculation."""
+    def test_pace_calculation_metric(self, mock_strava_activities):
+        """Test pace calculation in metric units.
+
+        Run fixture: distance=5000m, moving_time=1800s → 360 s/km = 6:00 min/km.
+        """
         coordinator = MagicMock()
         coordinator.data = {
             "activities": mock_strava_activities,
             "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
         }
         coordinator.entry = MagicMock()
+        coordinator.entry.options = {
+            CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_METRIC
+        }
+        coordinator.entry.data = {}
         mock_hass = MagicMock()
         mock_hass.config.units = METRIC_SYSTEM
         coordinator.hass = mock_hass
@@ -438,8 +446,39 @@ class TestStravaActivityMetricSensor:
         sensor.hass = mock_hass
 
         value = sensor.native_value
-        assert value is not None
-        assert ":" in value  # Should be in MM:SS format
+        assert value == "6:00 min/km"
+
+    def test_pace_calculation_imperial(self, mock_strava_activities):
+        """Test pace calculation in imperial units.
+
+        Run fixture: distance=5000m, moving_time=1800s → 360 s/km → 579 s/mi = 9:39 min/mi.
+        Previously bugged: multiplied by 0.621371 giving ~3:43 min/mi instead of ~9:39 min/mi.
+        """
+        coordinator = MagicMock()
+        coordinator.data = {
+            "activities": mock_strava_activities,
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+        coordinator.entry = MagicMock()
+        coordinator.entry.options = {
+            CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL
+        }
+        coordinator.entry.data = {}
+        mock_hass = MagicMock()
+        mock_hass.config.units = METRIC_SYSTEM
+        coordinator.hass = mock_hass
+
+        sensor = StravaActivityMetricSensor(
+            coordinator=coordinator,
+            activity_type="Run",
+            metric_type=CONF_SENSOR_PACE,
+            athlete_id="12345",
+        )
+        sensor.hass = mock_hass
+
+        value = sensor.native_value
+        # 360 s/km * 1.60934 km/mi = 579.36 s/mi = 9:39 min/mi
+        assert value == "9:39 min/mi"
 
     def test_speed_calculation(self, mock_strava_activities):
         """Test speed calculation."""

--- a/tests/custom_components/ha_strava/test_update_activity.py
+++ b/tests/custom_components/ha_strava/test_update_activity.py
@@ -1,0 +1,934 @@
+"""Test update_activity service and coordinator method for ha_strava."""
+
+from datetime import datetime as dt
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ServiceValidationError
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.ha_strava import async_setup_entry, async_unload_entry
+from custom_components.ha_strava.const import (
+    CONF_ATTR_SPORT_TYPE,
+    CONF_SENSOR_ACTIVITY_TYPE,
+    CONF_SENSOR_DATE,
+    CONF_SENSOR_DISTANCE,
+    CONF_SENSOR_ID,
+    CONF_SENSOR_TITLE,
+    DOMAIN,
+    OAUTH2_SCOPES,
+    SERVICE_UPDATE_ACTIVITY,
+)
+from custom_components.ha_strava.coordinator import StravaDataUpdateCoordinator
+
+
+class TestAsyncUpdateActivity:
+    """Test StravaDataUpdateCoordinator.async_update_activity method."""
+
+    @pytest.mark.asyncio
+    async def test_update_activity_success(
+        self, hass: HomeAssistant, mock_config_entry, aioresponses_mock
+    ):
+        """Test successful activity sport_type update."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        coordinator.data = {
+            "activities": [
+                {
+                    CONF_SENSOR_ID: 12345,
+                    CONF_SENSOR_TITLE: "Morning Run",
+                    CONF_SENSOR_ACTIVITY_TYPE: "Run",
+                    CONF_ATTR_SPORT_TYPE: "Run",
+                    CONF_SENSOR_DISTANCE: 5000.0,
+                    CONF_SENSOR_DATE: "2024-01-01T06:00:00Z",
+                },
+            ],
+            "summary_stats": {},
+            "images": [],
+            "gear": [],
+        }
+
+        updated_activity_response = {
+            "id": 12345,
+            "name": "Morning Run",
+            "type": "Run",
+            "sport_type": "TrailRun",
+            "athlete": {"id": 12345},
+            "distance": 5000.0,
+            "moving_time": 1800,
+            "elapsed_time": 1900,
+            "total_elevation_gain": 100.0,
+            "start_date_local": "2024-01-01T06:00:00Z",
+            "kudos_count": 5,
+            "achievement_count": 2,
+        }
+
+        aioresponses_mock.put(
+            "https://www.strava.com/api/v3/activities/12345",
+            payload=updated_activity_response,
+            status=200,
+        )
+
+        await coordinator.async_update_activity(12345, sport_type="TrailRun")
+
+        activities = coordinator.data["activities"]
+        assert len(activities) == 1
+        updated = next(a for a in activities if a[CONF_SENSOR_ID] == 12345)
+        assert updated[CONF_ATTR_SPORT_TYPE] == "TrailRun"
+        assert updated[CONF_SENSOR_ACTIVITY_TYPE] == "TrailRun"
+
+    @pytest.mark.asyncio
+    async def test_update_activity_string_id(
+        self, hass: HomeAssistant, mock_config_entry, aioresponses_mock
+    ):
+        """Test activity update with string activity_id."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        coordinator.data = {
+            "activities": [
+                {
+                    CONF_SENSOR_ID: 99999,
+                    CONF_SENSOR_TITLE: "Afternoon Ride",
+                    CONF_SENSOR_ACTIVITY_TYPE: "Ride",
+                    CONF_ATTR_SPORT_TYPE: "Ride",
+                    CONF_SENSOR_DISTANCE: 25000.0,
+                    CONF_SENSOR_DATE: "2024-01-02T14:00:00Z",
+                },
+            ],
+            "summary_stats": {},
+            "images": [],
+            "gear": [],
+        }
+
+        updated_activity_response = {
+            "id": 99999,
+            "name": "Afternoon Ride",
+            "type": "Ride",
+            "sport_type": "GravelRide",
+            "athlete": {"id": 12345},
+            "distance": 25000.0,
+            "moving_time": 3600,
+            "elapsed_time": 3700,
+            "total_elevation_gain": 500.0,
+            "start_date_local": "2024-01-02T14:00:00Z",
+            "kudos_count": 3,
+            "achievement_count": 1,
+        }
+
+        aioresponses_mock.put(
+            "https://www.strava.com/api/v3/activities/99999",
+            payload=updated_activity_response,
+            status=200,
+        )
+
+        await coordinator.async_update_activity("99999", sport_type="GravelRide")
+
+        activities = coordinator.data["activities"]
+        updated = next(a for a in activities if a[CONF_SENSOR_ID] == 99999)
+        assert updated[CONF_ATTR_SPORT_TYPE] == "GravelRide"
+
+    @pytest.mark.asyncio
+    async def test_update_activity_not_in_cache(
+        self, hass: HomeAssistant, mock_config_entry, aioresponses_mock
+    ):
+        """Test updating an activity that is not already in the coordinator's cache."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        coordinator.data = {
+            "activities": [],
+            "summary_stats": {},
+            "images": [],
+            "gear": [],
+        }
+
+        updated_activity_response = {
+            "id": 77777,
+            "name": "New Activity",
+            "type": "Run",
+            "sport_type": "Run",
+            "athlete": {"id": 12345},
+            "distance": 10000.0,
+            "moving_time": 3600,
+            "elapsed_time": 3700,
+            "total_elevation_gain": 200.0,
+            "start_date_local": "2024-01-03T08:00:00Z",
+            "kudos_count": 0,
+            "achievement_count": 0,
+        }
+
+        aioresponses_mock.put(
+            "https://www.strava.com/api/v3/activities/77777",
+            payload=updated_activity_response,
+            status=200,
+        )
+
+        await coordinator.async_update_activity(77777, sport_type="Run")
+
+        activities = coordinator.data["activities"]
+        assert len(activities) == 1
+        assert activities[0][CONF_SENSOR_ID] == 77777
+
+    @pytest.mark.asyncio
+    async def test_update_activity_api_error(
+        self, hass: HomeAssistant, mock_config_entry, aioresponses_mock
+    ):
+        """Test activity update with API error response."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        coordinator.data = {
+            "activities": [],
+            "summary_stats": {},
+            "images": [],
+            "gear": [],
+        }
+
+        aioresponses_mock.put(
+            "https://www.strava.com/api/v3/activities/12345",
+            status=500,
+            payload={"message": "Internal server error"},
+        )
+
+        with pytest.raises(UpdateFailed):
+            await coordinator.async_update_activity(12345, sport_type="TrailRun")
+
+    @pytest.mark.asyncio
+    async def test_update_activity_unauthorized_raises_auth_failed(
+        self, hass: HomeAssistant, mock_config_entry, aioresponses_mock
+    ):
+        """Test that 401 raises ConfigEntryAuthFailed (triggers HA reauth flow)."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        coordinator.data = {
+            "activities": [],
+            "summary_stats": {},
+            "images": [],
+            "gear": [],
+        }
+
+        aioresponses_mock.put(
+            "https://www.strava.com/api/v3/activities/12345",
+            status=401,
+            payload={"message": "Unauthorized"},
+        )
+
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coordinator.async_update_activity(12345, sport_type="TrailRun")
+
+    @pytest.mark.asyncio
+    async def test_update_activity_forbidden_raises_auth_failed(
+        self, hass: HomeAssistant, mock_config_entry, aioresponses_mock
+    ):
+        """Test that 403 raises ConfigEntryAuthFailed (triggers HA reauth flow)."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        coordinator.data = {
+            "activities": [],
+            "summary_stats": {},
+            "images": [],
+            "gear": [],
+        }
+
+        aioresponses_mock.put(
+            "https://www.strava.com/api/v3/activities/12345",
+            status=403,
+            payload={"message": "Forbidden"},
+        )
+
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coordinator.async_update_activity(12345, sport_type="TrailRun")
+
+    @pytest.mark.asyncio
+    async def test_update_activity_rate_limit_then_success(
+        self, hass: HomeAssistant, mock_config_entry, aioresponses_mock
+    ):
+        """Test activity update retries on 429 rate limit then succeeds."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        coordinator.data = {
+            "activities": [
+                {
+                    CONF_SENSOR_ID: 12345,
+                    CONF_SENSOR_TITLE: "Morning Run",
+                    CONF_SENSOR_ACTIVITY_TYPE: "Run",
+                    CONF_ATTR_SPORT_TYPE: "Run",
+                    CONF_SENSOR_DISTANCE: 5000.0,
+                    CONF_SENSOR_DATE: "2024-01-01T06:00:00Z",
+                },
+            ],
+            "summary_stats": {},
+            "images": [],
+            "gear": [],
+        }
+
+        updated_activity_response = {
+            "id": 12345,
+            "name": "Morning Run",
+            "type": "Run",
+            "sport_type": "TrailRun",
+            "athlete": {"id": 12345},
+            "distance": 5000.0,
+            "moving_time": 1800,
+            "elapsed_time": 1900,
+            "total_elevation_gain": 100.0,
+            "start_date_local": "2024-01-01T06:00:00Z",
+            "kudos_count": 5,
+            "achievement_count": 2,
+        }
+
+        aioresponses_mock.put(
+            "https://www.strava.com/api/v3/activities/12345",
+            status=429,
+            headers={"Retry-After": "1"},
+            payload={"message": "Rate limit exceeded"},
+        )
+        aioresponses_mock.put(
+            "https://www.strava.com/api/v3/activities/12345",
+            payload=updated_activity_response,
+            status=200,
+        )
+
+        await coordinator.async_update_activity(12345, sport_type="TrailRun")
+
+        activities = coordinator.data["activities"]
+        updated = next(a for a in activities if a[CONF_SENSOR_ID] == 12345)
+        assert updated[CONF_ATTR_SPORT_TYPE] == "TrailRun"
+
+    @pytest.mark.asyncio
+    async def test_update_activity_rate_limit_max_attempts(
+        self, hass: HomeAssistant, mock_config_entry, aioresponses_mock
+    ):
+        """Test activity update fails after max retry attempts on 429."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        coordinator.data = {
+            "activities": [],
+            "summary_stats": {},
+            "images": [],
+            "gear": [],
+        }
+
+        aioresponses_mock.put(
+            "https://www.strava.com/api/v3/activities/12345",
+            status=429,
+            headers={"Retry-After": "1"},
+            payload={"message": "Rate limit exceeded"},
+            repeat=True,
+        )
+
+        with pytest.raises(UpdateFailed):
+            await coordinator.async_update_activity(12345, sport_type="TrailRun")
+
+    @pytest.mark.asyncio
+    async def test_update_activity_preserves_other_activities(
+        self, hass: HomeAssistant, mock_config_entry, aioresponses_mock
+    ):
+        """Test that updating one activity doesn't affect others in the cache."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        coordinator.data = {
+            "activities": [
+                {
+                    CONF_SENSOR_ID: 111,
+                    CONF_SENSOR_TITLE: "Morning Run",
+                    CONF_SENSOR_ACTIVITY_TYPE: "Run",
+                    CONF_ATTR_SPORT_TYPE: "Run",
+                    CONF_SENSOR_DISTANCE: 5000.0,
+                    CONF_SENSOR_DATE: dt(2024, 1, 1, 18, 0, 0),
+                },
+            ],
+            "summary_stats": {},
+            "images": [],
+            "gear": [],
+        }
+
+        updated_activity_response = {
+            "id": 111,
+            "name": "Morning Run",
+            "type": "Run",
+            "sport_type": "TrailRun",
+            "athlete": {"id": 12345},
+            "distance": 5000.0,
+            "moving_time": 1800,
+            "elapsed_time": 1900,
+            "total_elevation_gain": 100.0,
+            "start_date_local": "2024-01-01T18:00:00Z",
+            "kudos_count": 5,
+            "achievement_count": 2,
+        }
+
+        aioresponses_mock.put(
+            "https://www.strava.com/api/v3/activities/111",
+            payload=updated_activity_response,
+            status=200,
+        )
+
+        await coordinator.async_update_activity(111, sport_type="TrailRun")
+
+        activities = coordinator.data["activities"]
+        assert len(activities) == 1
+
+        updated = activities[0]
+        assert updated[CONF_SENSOR_ID] == 111
+        assert updated[CONF_ATTR_SPORT_TYPE] == "TrailRun"
+
+    @pytest.mark.asyncio
+    async def test_update_activity_preserves_other_data_keys(
+        self, hass: HomeAssistant, mock_config_entry, aioresponses_mock
+    ):
+        """Test that updating an activity preserves summary_stats, images, gear."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        coordinator.data = {
+            "activities": [
+                {
+                    CONF_SENSOR_ID: 12345,
+                    CONF_SENSOR_TITLE: "Morning Run",
+                    CONF_SENSOR_ACTIVITY_TYPE: "Run",
+                    CONF_ATTR_SPORT_TYPE: "Run",
+                    CONF_SENSOR_DISTANCE: 5000.0,
+                    CONF_SENSOR_DATE: "2024-01-01T06:00:00Z",
+                },
+            ],
+            "summary_stats": {"some": "stats"},
+            "images": [{"url": "https://example.com/photo.jpg"}],
+            "gear": [{"id": "g123", "name": "Shoes"}],
+        }
+
+        updated_activity_response = {
+            "id": 12345,
+            "name": "Morning Run",
+            "type": "Run",
+            "sport_type": "TrailRun",
+            "athlete": {"id": 12345},
+            "distance": 5000.0,
+            "moving_time": 1800,
+            "elapsed_time": 1900,
+            "total_elevation_gain": 100.0,
+            "start_date_local": "2024-01-01T06:00:00Z",
+            "kudos_count": 5,
+            "achievement_count": 2,
+        }
+
+        aioresponses_mock.put(
+            "https://www.strava.com/api/v3/activities/12345",
+            payload=updated_activity_response,
+            status=200,
+        )
+
+        await coordinator.async_update_activity(12345, sport_type="TrailRun")
+
+        assert coordinator.data["summary_stats"] == {"some": "stats"}
+        assert coordinator.data["images"] == [{"url": "https://example.com/photo.jpg"}]
+        assert coordinator.data["gear"] == [{"id": "g123", "name": "Shoes"}]
+
+    @pytest.mark.asyncio
+    async def test_update_activity_network_error(
+        self, hass: HomeAssistant, mock_config_entry, aioresponses_mock
+    ):
+        """Test activity update with network error (aiohttp.ClientError)."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        coordinator.data = {
+            "activities": [],
+            "summary_stats": {},
+            "images": [],
+            "gear": [],
+        }
+
+        aioresponses_mock.put(
+            "https://www.strava.com/api/v3/activities/12345",
+            exception=Exception("Connection refused"),
+        )
+
+        with pytest.raises(Exception):
+            await coordinator.async_update_activity(12345, sport_type="TrailRun")
+
+    @pytest.mark.asyncio
+    async def test_update_activity_with_none_data(
+        self, hass: HomeAssistant, mock_config_entry, aioresponses_mock
+    ):
+        """Test activity update when coordinator.data is None."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        assert coordinator.data is None
+
+        updated_activity_response = {
+            "id": 12345,
+            "name": "Morning Run",
+            "type": "Run",
+            "sport_type": "TrailRun",
+            "athlete": {"id": 12345},
+            "distance": 5000.0,
+            "moving_time": 1800,
+            "elapsed_time": 1900,
+            "total_elevation_gain": 100.0,
+            "start_date_local": "2024-01-01T06:00:00Z",
+            "kudos_count": 5,
+            "achievement_count": 2,
+        }
+
+        aioresponses_mock.put(
+            "https://www.strava.com/api/v3/activities/12345",
+            payload=updated_activity_response,
+            status=200,
+        )
+
+        await coordinator.async_update_activity(12345, sport_type="TrailRun")
+
+        activities = coordinator.data["activities"]
+        assert len(activities) == 1
+        assert activities[0][CONF_SENSOR_ID] == 12345
+        assert activities[0][CONF_ATTR_SPORT_TYPE] == "TrailRun"
+
+    @pytest.mark.asyncio
+    async def test_update_activity_multiple_fields(
+        self, hass: HomeAssistant, mock_config_entry, aioresponses_mock
+    ):
+        """Test updating sport_type and name together."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        coordinator.data = {
+            "activities": [
+                {
+                    CONF_SENSOR_ID: 12345,
+                    CONF_SENSOR_TITLE: "Tennis with friends",
+                    CONF_SENSOR_ACTIVITY_TYPE: "Tennis",
+                    CONF_ATTR_SPORT_TYPE: "Tennis",
+                    CONF_SENSOR_DISTANCE: 0.0,
+                    CONF_SENSOR_DATE: "2024-01-01T06:00:00Z",
+                },
+            ],
+            "summary_stats": {},
+            "images": [],
+            "gear": [],
+        }
+
+        updated_activity_response = {
+            "id": 12345,
+            "name": "Squash with friends",
+            "type": "Racquet",
+            "sport_type": "Squash",
+            "athlete": {"id": 12345},
+            "distance": 0.0,
+            "moving_time": 3600,
+            "elapsed_time": 3700,
+            "total_elevation_gain": 0.0,
+            "start_date_local": "2024-01-01T06:00:00Z",
+            "kudos_count": 0,
+            "achievement_count": 0,
+        }
+
+        aioresponses_mock.put(
+            "https://www.strava.com/api/v3/activities/12345",
+            payload=updated_activity_response,
+            status=200,
+        )
+
+        await coordinator.async_update_activity(
+            12345, sport_type="Squash", name="Squash with friends"
+        )
+
+        activities = coordinator.data["activities"]
+        assert len(activities) == 1
+        updated = activities[0]
+        assert updated[CONF_ATTR_SPORT_TYPE] == "Squash"
+        assert updated[CONF_SENSOR_TITLE] == "Squash with friends"
+
+    @pytest.mark.asyncio
+    async def test_update_activity_private_note(
+        self, hass: HomeAssistant, mock_config_entry, aioresponses_mock
+    ):
+        """Test that private_note is sent to the Strava API."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        coordinator.data = {
+            "activities": [
+                {
+                    CONF_SENSOR_ID: 12345,
+                    CONF_SENSOR_TITLE: "Morning Run",
+                    CONF_SENSOR_ACTIVITY_TYPE: "Run",
+                    CONF_ATTR_SPORT_TYPE: "Run",
+                    CONF_SENSOR_DISTANCE: 5000.0,
+                    CONF_SENSOR_DATE: "2024-01-01T06:00:00Z",
+                },
+            ],
+            "summary_stats": {},
+            "images": [],
+            "gear": [],
+        }
+
+        updated_activity_response = {
+            "id": 12345,
+            "name": "Morning Run",
+            "type": "Run",
+            "sport_type": "Run",
+            "athlete": {"id": 12345},
+            "distance": 5000.0,
+            "moving_time": 1800,
+            "elapsed_time": 1900,
+            "total_elevation_gain": 100.0,
+            "start_date_local": "2024-01-01T06:00:00Z",
+            "kudos_count": 5,
+            "achievement_count": 2,
+        }
+
+        aioresponses_mock.put(
+            "https://www.strava.com/api/v3/activities/12345",
+            payload=updated_activity_response,
+            status=200,
+        )
+
+        await coordinator.async_update_activity(
+            12345, private_note="tagged:commute source:automation"
+        )
+
+        activities = coordinator.data["activities"]
+        assert len(activities) == 1
+        assert activities[0][CONF_SENSOR_ID] == 12345
+
+
+class TestUpdateActivityService:
+    """Test update_activity service registration and handling."""
+
+    @pytest.mark.asyncio
+    async def test_service_registered_on_setup(
+        self, hass, mock_config_entry, mock_coordinator
+    ):
+        """Test that update_activity service is registered during setup."""
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        result = await async_setup_entry(hass, mock_config_entry)
+                        assert result is True
+
+        assert hass.services.has_service(DOMAIN, SERVICE_UPDATE_ACTIVITY)
+
+    @pytest.mark.asyncio
+    async def test_service_not_registered_twice(
+        self, hass, mock_config_entry, mock_coordinator
+    ):
+        """Test that service is only registered once even with multiple entries."""
+        entry1 = MagicMock()
+        entry1.entry_id = "entry_1"
+        entry1.add_update_listener = MagicMock()
+        entry1.async_on_unload = MagicMock()
+
+        entry2 = MagicMock()
+        entry2.entry_id = "entry_2"
+        entry2.add_update_listener = MagicMock()
+        entry2.async_on_unload = MagicMock()
+
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        await async_setup_entry(hass, entry1)
+                        await async_setup_entry(hass, entry2)
+
+        assert hass.services.has_service(DOMAIN, SERVICE_UPDATE_ACTIVITY)
+
+    @pytest.mark.asyncio
+    async def test_service_calls_coordinator_update(
+        self, hass, mock_config_entry, mock_coordinator
+    ):
+        """Test that calling the service delegates to coordinator.async_update_activity."""
+        mock_coordinator.async_update_activity = AsyncMock()
+        mock_coordinator.data = {
+            "activities": [{"id": 12345, "sport_type": "Run"}],
+        }
+
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        await async_setup_entry(hass, mock_config_entry)
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_UPDATE_ACTIVITY,
+            {"activity_id": "12345", "sport_type": "TrailRun"},
+            blocking=True,
+        )
+
+        mock_coordinator.async_update_activity.assert_called_once_with(
+            "12345", sport_type="TrailRun"
+        )
+
+    @pytest.mark.asyncio
+    async def test_service_raises_error_when_activity_not_found(
+        self, hass, mock_config_entry, mock_coordinator
+    ):
+        """Test that service raises ServiceValidationError when activity not in any cache."""
+        mock_coordinator.async_update_activity = AsyncMock()
+        mock_coordinator.data = {
+            "activities": [],
+        }
+
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        await async_setup_entry(hass, mock_config_entry)
+
+        with pytest.raises(ServiceValidationError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_UPDATE_ACTIVITY,
+                {"activity_id": "99999", "sport_type": "Ride"},
+                blocking=True,
+            )
+
+        mock_coordinator.async_update_activity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_service_passes_private_note(
+        self, hass, mock_config_entry, mock_coordinator
+    ):
+        """Test that the service passes private_note to the coordinator."""
+        mock_coordinator.async_update_activity = AsyncMock()
+        mock_coordinator.data = {
+            "activities": [{"id": 12345, "sport_type": "Run"}],
+        }
+
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        await async_setup_entry(hass, mock_config_entry)
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_UPDATE_ACTIVITY,
+            {"activity_id": "12345", "private_note": "tagged:commute"},
+            blocking=True,
+        )
+
+        mock_coordinator.async_update_activity.assert_called_once_with(
+            "12345", private_note="tagged:commute"
+        )
+
+    @pytest.mark.asyncio
+    async def test_service_rejects_invalid_sport_type(
+        self, hass, mock_config_entry, mock_coordinator
+    ):
+        """Test that the service rejects an invalid sport_type."""
+        mock_coordinator.async_update_activity = AsyncMock()
+        mock_coordinator.data = {"activities": []}
+
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        await async_setup_entry(hass, mock_config_entry)
+
+        with pytest.raises(Exception):  # voluptuous.Invalid
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_UPDATE_ACTIVITY,
+                {"activity_id": "12345", "sport_type": "NotARealSport"},
+                blocking=True,
+            )
+
+        mock_coordinator.async_update_activity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_service_rejects_other_sport_type(
+        self, hass, mock_config_entry, mock_coordinator
+    ):
+        """Test that the service rejects 'Other' as sport_type (internal bucket only)."""
+        mock_coordinator.async_update_activity = AsyncMock()
+        mock_coordinator.data = {"activities": []}
+
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        await async_setup_entry(hass, mock_config_entry)
+
+        with pytest.raises(Exception):  # voluptuous.Invalid
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_UPDATE_ACTIVITY,
+                {"activity_id": "12345", "sport_type": "Other"},
+                blocking=True,
+            )
+
+        mock_coordinator.async_update_activity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_service_rejects_missing_activity_id(
+        self, hass, mock_config_entry, mock_coordinator
+    ):
+        """Test that the service rejects a call missing activity_id."""
+        mock_coordinator.async_update_activity = AsyncMock()
+        mock_coordinator.data = {"activities": []}
+
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        await async_setup_entry(hass, mock_config_entry)
+
+        with pytest.raises(Exception):  # voluptuous.Invalid
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_UPDATE_ACTIVITY,
+                {"sport_type": "Run"},
+                blocking=True,
+            )
+
+        mock_coordinator.async_update_activity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_service_removed_on_last_entry_unload(
+        self, hass, mock_config_entry, mock_coordinator, aioresponses_mock
+    ):
+        """Test that the service is removed when the last config entry is unloaded."""
+        mock_coordinator.async_update_activity = AsyncMock()
+        mock_coordinator.data = {"activities": []}
+
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        await async_setup_entry(hass, mock_config_entry)
+
+        assert hass.services.has_service(DOMAIN, SERVICE_UPDATE_ACTIVITY)
+
+        result = await async_unload_entry(hass, mock_config_entry)
+        assert result is True
+
+        assert not hass.services.has_service(DOMAIN, SERVICE_UPDATE_ACTIVITY)
+
+
+class TestOAuthScopeConstant:
+    """Test that OAuth scopes include activity:write."""
+
+    def test_oauth_scopes_include_activity_write(self):
+        """Test that OAUTH2_SCOPES includes activity:write."""
+        scopes = OAUTH2_SCOPES.split(",")
+        assert "activity:write" in scopes
+
+    def test_oauth_scopes_include_activity_read_all(self):
+        """Test that OAUTH2_SCOPES still includes activity:read_all."""
+        scopes = OAUTH2_SCOPES.split(",")
+        assert "activity:read_all" in scopes
+
+    def test_oauth_scopes_include_profile_read_all(self):
+        """Test that OAUTH2_SCOPES still includes profile:read_all."""
+        scopes = OAUTH2_SCOPES.split(",")
+        assert "profile:read_all" in scopes
+
+
+class TestServiceUpdateActivityConstant:
+    """Test the SERVICE_UPDATE_ACTIVITY constant."""
+
+    def test_service_name_value(self):
+        """Test the service name constant value."""
+        assert SERVICE_UPDATE_ACTIVITY == "update_activity"


### PR DESCRIPTION
## Summary
- **fix: correct imperial pace conversion** (#312) — pace was multiplying by 0.621371 instead of 1.60934, showing ~3:43 instead of ~9:39 min/mi
- **feat: add `update_activity` service** (#314) — update name, description, sport type, gear, commute, trainer, hide_from_home, and private_note via HA service call; requires `activity:write` OAuth scope
- **feat: pace sensors now numeric** (#316) — `native_value` is decimal minutes (e.g. `6.0`) with `native_unit_of_measurement` of `min/km` or `min/mi`, enabling history graphs; two attributes added:
  - `formatted_pace`: `"12:32 min/mi"` (MM:SS with unit)
  - `pace`: `"12:32"` (MM:SS only, for templates)
- **chore: bump version to 4.2.1** (#317)

## Breaking change
Pace sensor state was previously a string (`"12:32 min/mi"`), now a float (`12.533`). Use the `formatted_pace` or `pace` attribute as a drop-in replacement in templates/automations.