### PR TITLE
feat: add get_activity_route service

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,32 @@ The gear items are sorted by distance (most used first), and the integration res
 2. The integration now fetches up to 200 activities instead of being limited to 10.
 3. Device source tracking automatically detects the device used for each activity (Garmin, Apple Watch, etc.).
 
+## Displaying an Activity Route/Map
+
+Activity sensors expose a `polyline` attribute containing the route as a Google-encoded polyline string. Since that string isn't directly usable by map cards, the integration provides the `ha_strava.get_activity_route` service to decode it into a list of `{lat, lon}` coordinates on demand — keeping the raw encoded string in sensor attributes (recorder-friendly) while giving you real coordinates when you need to render a map.
+
+**Calling the service:**
+
+```yaml
+service: ha_strava.get_activity_route
+data:
+  activity_id: "1234567890"
+```
+
+The service returns a response shaped like:
+
+```yaml
+route:
+  - lat: 38.5
+    lon: -120.2
+  - lat: 40.7
+    lon: -120.95
+```
+
+**Rendering the route on a map card:**
+
+The [journey-viewer-card](https://github.com/nledenyi/journey-viewer-card) Lovelace card can render Strava-style per-activity maps using this service. It reads activity data from any sensor matching its [data contract](https://github.com/nledenyi/journey-viewer-card/blob/main/README.md#data-contract) and lazily loads the route via a configurable `route_service` hook, which you can point at `ha_strava.get_activity_route`. See the card's documentation for full setup instructions.
+
 ## Contributors
 
 - [@craibo](https://github.com/craibo)

--- a/custom_components/ha_strava/__init__.py
+++ b/custom_components/ha_strava/__init__.py
@@ -13,7 +13,12 @@ from aiohttp.web import Request, Response, json_response
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_WEBHOOK_ID
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+)
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_registry import async_entries_for_config_entry
@@ -21,13 +26,17 @@ from homeassistant.helpers.entity_registry import async_get as er_async_get
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 
 from .const import (
+    CONF_ATTR_POLYLINE,
     CONF_CALLBACK_URL,
+    CONF_SENSOR_ID,
     DOMAIN,
+    SERVICE_GET_ACTIVITY_ROUTE,
     SERVICE_UPDATE_ACTIVITY,
     SUPPORTED_ACTIVITY_TYPES,
     WEBHOOK_SUBSCRIPTION_URL,
 )
 from .coordinator import StravaDataUpdateCoordinator
+from .polyline import decode_polyline
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -404,6 +413,47 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             ),
         )
 
+    # Register the get_activity_route service once per domain (not per entry)
+    if not hass.services.has_service(DOMAIN, SERVICE_GET_ACTIVITY_ROUTE):
+
+        async def async_handle_get_activity_route(call: ServiceCall) -> ServiceResponse:
+            """Handle the get_activity_route service call."""
+            activity_id = call.data["activity_id"]
+
+            target_activity = None
+            for coord in hass.data[DOMAIN].values():
+                current_data = coord.data or {}
+                for activity in current_data.get("activities") or []:
+                    if str(activity.get(CONF_SENSOR_ID)) == str(activity_id):
+                        target_activity = activity
+                        break
+                if target_activity:
+                    break
+
+            if target_activity is None:
+                raise ServiceValidationError(
+                    "Activity not found in any tracked athlete's recent activities. "
+                    "Trigger a refresh first or check the activity ID."
+                )
+
+            encoded_polyline = target_activity.get(CONF_ATTR_POLYLINE)
+            if not encoded_polyline:
+                raise ServiceValidationError(
+                    f"Activity {activity_id} has no route/polyline data available."
+                )
+
+            decoded = decode_polyline(encoded_polyline)
+
+            return {"route": [{"lat": lat, "lon": lon} for lat, lon in decoded]}
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_GET_ACTIVITY_ROUTE,
+            async_handle_get_activity_route,
+            schema=vol.Schema({vol.Required("activity_id"): vol.Coerce(str)}),
+            supports_response=SupportsResponse.ONLY,
+        )
+
     # Register update listener for options changes
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
@@ -442,9 +492,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         hass.data[DOMAIN].pop(entry.entry_id)
 
-        # Remove the service if no more entries remain
+        # Remove the services if no more entries remain
         if not hass.data[DOMAIN]:
             hass.services.async_remove(DOMAIN, SERVICE_UPDATE_ACTIVITY)
+            hass.services.async_remove(DOMAIN, SERVICE_GET_ACTIVITY_ROUTE)
 
     return unload_ok
 

--- a/custom_components/ha_strava/const.py
+++ b/custom_components/ha_strava/const.py
@@ -13,6 +13,7 @@ OAUTH2_SCOPES = "activity:read_all,profile:read_all,activity:write"
 
 # Services
 SERVICE_UPDATE_ACTIVITY = "update_activity"
+SERVICE_GET_ACTIVITY_ROUTE = "get_activity_route"
 
 # Camera Config
 CONF_PHOTOS = "conf_photos"

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.3.0"
+  "version": "4.3.1"
 }

--- a/custom_components/ha_strava/polyline.py
+++ b/custom_components/ha_strava/polyline.py
@@ -1,0 +1,40 @@
+"""Google encoded polyline algorithm decoder (precision 5).
+
+Reference: https://developers.google.com/maps/documentation/utilities/polylinealgorithm
+"""
+
+from __future__ import annotations
+
+
+def decode_polyline(polyline_str: str, precision: int = 5) -> list[tuple[float, float]]:
+    """Decode a Google encoded polyline string into a list of (lat, lon) tuples."""
+    if not polyline_str:
+        return []
+
+    index = 0
+    lat = 0
+    lon = 0
+    coordinates: list[tuple[float, float]] = []
+    factor = 10**precision
+    length = len(polyline_str)
+
+    while index < length:
+        for is_lat in (True, False):
+            shift = 0
+            result = 0
+            while True:
+                byte = ord(polyline_str[index]) - 63
+                index += 1
+                result |= (byte & 0x1F) << shift
+                shift += 5
+                if byte < 0x20:
+                    break
+            delta = ~(result >> 1) if (result & 1) else (result >> 1)
+            if is_lat:
+                lat += delta
+            else:
+                lon += delta
+
+        coordinates.append((lat / factor, lon / factor))
+
+    return coordinates

--- a/custom_components/ha_strava/services.yaml
+++ b/custom_components/ha_strava/services.yaml
@@ -123,3 +123,18 @@ update_activity:
       selector:
         text:
           multiline: true
+
+get_activity_route:
+  name: Get Activity Route
+  description: >-
+    Decode an activity's stored polyline (map.summary_polyline) into a list of
+    latitude/longitude coordinates. Returns the route on demand instead of storing
+    decoded coordinates in sensor attributes, keeping recorder history small.
+  fields:
+    activity_id:
+      name: Activity ID
+      description: The numeric Strava activity ID to fetch the route for.
+      required: true
+      example: "1234567890"
+      selector:
+        text:

--- a/info.md
+++ b/info.md
@@ -181,6 +181,32 @@ The gear items are sorted by distance (most used first), and the integration res
 1. Changing the unit system setting will require a restart of Home Assistant to be fully applied.
 2. The new architecture provides more reliable and efficient data processing compared to previous versions.
 
+## Displaying an Activity Route/Map
+
+Activity sensors expose a `polyline` attribute containing the route as a Google-encoded polyline string. Since that string isn't directly usable by map cards, the integration provides the `ha_strava.get_activity_route` service to decode it into a list of `{lat, lon}` coordinates on demand — keeping the raw encoded string in sensor attributes (recorder-friendly) while giving you real coordinates when you need to render a map.
+
+**Calling the service:**
+
+```yaml
+service: ha_strava.get_activity_route
+data:
+  activity_id: "1234567890"
+```
+
+The service returns a response shaped like:
+
+```yaml
+route:
+  - lat: 38.5
+    lon: -120.2
+  - lat: 40.7
+    lon: -120.95
+```
+
+**Rendering the route on a map card:**
+
+The [journey-viewer-card](https://github.com/nledenyi/journey-viewer-card) Lovelace card can render Strava-style per-activity maps using this service. It reads activity data from any sensor matching its [data contract](https://github.com/nledenyi/journey-viewer-card/blob/main/README.md#data-contract) and lazily loads the route via a configurable `route_service` hook, which you can point at `ha_strava.get_activity_route`. See the card's documentation for full setup instructions.
+
 ## Contributors
 
 - [@craibo](https://github.com/craibo)

--- a/tests/custom_components/ha_strava/test_get_activity_route.py
+++ b/tests/custom_components/ha_strava/test_get_activity_route.py
@@ -1,0 +1,301 @@
+"""Test get_activity_route service and polyline decoder for ha_strava."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.exceptions import ServiceValidationError
+
+from custom_components.ha_strava import async_setup_entry, async_unload_entry
+from custom_components.ha_strava.const import (
+    CONF_ATTR_POLYLINE,
+    CONF_SENSOR_ID,
+    DOMAIN,
+    SERVICE_GET_ACTIVITY_ROUTE,
+)
+from custom_components.ha_strava.polyline import decode_polyline
+
+ENCODED_POLYLINE = "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+DECODED_ROUTE = [(38.5, -120.2), (40.7, -120.95), (43.252, -126.453)]
+
+
+class TestDecodePolyline:
+    """Test the decode_polyline pure function."""
+
+    def test_decode_known_polyline(self):
+        """Test decoding the canonical Google example polyline."""
+        assert decode_polyline(ENCODED_POLYLINE) == DECODED_ROUTE
+
+    def test_decode_empty_string_returns_empty_list(self):
+        """Test that an empty string decodes to an empty list."""
+        assert decode_polyline("") == []
+
+    def test_decode_none_returns_empty_list(self):
+        """Test that None decodes to an empty list."""
+        assert decode_polyline(None) == []
+
+    def test_decode_single_point(self):
+        """Test decoding a polyline containing a single point."""
+        assert decode_polyline("_p~iF~ps|U") == [(38.5, -120.2)]
+
+
+class TestGetActivityRouteService:
+    """Test get_activity_route service registration and handling."""
+
+    @pytest.mark.asyncio
+    async def test_service_registered_on_setup(
+        self, hass, mock_config_entry, mock_coordinator
+    ):
+        """Test that get_activity_route service is registered during setup."""
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        result = await async_setup_entry(hass, mock_config_entry)
+                        assert result is True
+
+        assert hass.services.has_service(DOMAIN, SERVICE_GET_ACTIVITY_ROUTE)
+
+    @pytest.mark.asyncio
+    async def test_service_not_registered_twice(
+        self, hass, mock_config_entry, mock_coordinator
+    ):
+        """Test that service is only registered once even with multiple entries."""
+        entry1 = MagicMock()
+        entry1.entry_id = "entry_1"
+        entry1.add_update_listener = MagicMock()
+        entry1.async_on_unload = MagicMock()
+
+        entry2 = MagicMock()
+        entry2.entry_id = "entry_2"
+        entry2.add_update_listener = MagicMock()
+        entry2.async_on_unload = MagicMock()
+
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        await async_setup_entry(hass, entry1)
+                        await async_setup_entry(hass, entry2)
+
+        assert hass.services.has_service(DOMAIN, SERVICE_GET_ACTIVITY_ROUTE)
+
+    @pytest.mark.asyncio
+    async def test_service_returns_decoded_route(
+        self, hass, mock_config_entry, mock_coordinator
+    ):
+        """Test that calling the service returns the decoded route."""
+        mock_coordinator.data = {
+            "activities": [
+                {CONF_SENSOR_ID: 12345, CONF_ATTR_POLYLINE: ENCODED_POLYLINE},
+            ],
+        }
+
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        await async_setup_entry(hass, mock_config_entry)
+
+        result = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_GET_ACTIVITY_ROUTE,
+            {"activity_id": "12345"},
+            blocking=True,
+            return_response=True,
+        )
+
+        assert result["route"] == [
+            {"lat": lat, "lon": lon} for lat, lon in DECODED_ROUTE
+        ]
+
+    @pytest.mark.asyncio
+    async def test_service_raises_error_when_activity_not_found(
+        self, hass, mock_config_entry, mock_coordinator
+    ):
+        """Test that service raises ServiceValidationError when activity not in any cache."""
+        mock_coordinator.data = {"activities": []}
+
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        await async_setup_entry(hass, mock_config_entry)
+
+        with pytest.raises(ServiceValidationError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_GET_ACTIVITY_ROUTE,
+                {"activity_id": "99999"},
+                blocking=True,
+                return_response=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_service_raises_error_when_polyline_missing(
+        self, hass, mock_config_entry, mock_coordinator
+    ):
+        """Test that service raises ServiceValidationError when polyline key is absent."""
+        mock_coordinator.data = {
+            "activities": [{CONF_SENSOR_ID: 12345}],
+        }
+
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        await async_setup_entry(hass, mock_config_entry)
+
+        with pytest.raises(ServiceValidationError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_GET_ACTIVITY_ROUTE,
+                {"activity_id": "12345"},
+                blocking=True,
+                return_response=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_service_raises_error_when_polyline_empty(
+        self, hass, mock_config_entry, mock_coordinator
+    ):
+        """Test that service raises ServiceValidationError when polyline is an empty string."""
+        mock_coordinator.data = {
+            "activities": [{CONF_SENSOR_ID: 12345, CONF_ATTR_POLYLINE: ""}],
+        }
+
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        await async_setup_entry(hass, mock_config_entry)
+
+        with pytest.raises(ServiceValidationError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_GET_ACTIVITY_ROUTE,
+                {"activity_id": "12345"},
+                blocking=True,
+                return_response=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_service_rejects_missing_activity_id(
+        self, hass, mock_config_entry, mock_coordinator
+    ):
+        """Test that the service rejects a call missing activity_id."""
+        mock_coordinator.data = {"activities": []}
+
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        await async_setup_entry(hass, mock_config_entry)
+
+        with pytest.raises(Exception):  # voluptuous.Invalid
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_GET_ACTIVITY_ROUTE,
+                {},
+                blocking=True,
+                return_response=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_service_removed_on_last_entry_unload(
+        self, hass, mock_config_entry, mock_coordinator
+    ):
+        """Test that the service is removed when the last config entry is unloaded."""
+        mock_coordinator.data = {"activities": []}
+
+        with patch(
+            "custom_components.ha_strava.StravaDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ):
+            with patch(
+                "custom_components.ha_strava.renew_webhook_subscription",
+                new_callable=AsyncMock,
+            ):
+                with patch.object(hass, "http", MagicMock()):
+                    with patch.object(
+                        hass.config_entries,
+                        "async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ):
+                        await async_setup_entry(hass, mock_config_entry)
+
+        assert hass.services.has_service(DOMAIN, SERVICE_GET_ACTIVITY_ROUTE)
+
+        result = await async_unload_entry(hass, mock_config_entry)
+        assert result is True
+
+        assert not hass.services.has_service(DOMAIN, SERVICE_GET_ACTIVITY_ROUTE)


### PR DESCRIPTION
## Summary
- Adds `ha_strava.get_activity_route`, a response service that decodes an activity's stored `map.summary_polyline` into a list of `{lat, lon}` coordinates
- Uses a hand-rolled Google polyline decoder (`polyline.py`) — no new dependency
- Keeps raw encoded polyline in sensor attributes (recorder-friendly); route coordinates are computed on demand
- Service is registered/unregistered alongside the existing `update_activity` service

Addresses #196 (route/map rendering support suggested by @nledenyi for use with map/Lovelace cards)