### PR TITLE
fix: avoid ZeroDivisionError in speed sensor

### DIFF
--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.3.1"
+  "version": "4.3.2"
 }

--- a/custom_components/ha_strava/sensor.py
+++ b/custom_components/ha_strava/sensor.py
@@ -693,7 +693,10 @@ class StravaActivityTypeSensor(CoordinatorEntity, SensorEntity):
     def _calculate_speed(self, activity):
         """Calculate speed for the activity."""
         distance = activity.get(CONF_SENSOR_DISTANCE, 0)
-        moving_time = activity.get(CONF_SENSOR_MOVING_TIME, 1)
+        moving_time = activity.get(CONF_SENSOR_MOVING_TIME, 0)
+
+        if distance == 0 or moving_time == 0:
+            return 0.0
 
         speed = (distance / 1000) / (moving_time / 3600)  # km/h
         is_metric = self._is_metric()
@@ -1142,7 +1145,10 @@ class StravaActivityMetricSensor(StravaActivityAttributeSensor):
     def _calculate_speed(self, activity):
         """Calculate speed for the activity."""
         distance = activity.get(CONF_SENSOR_DISTANCE, 0)
-        moving_time = activity.get(CONF_SENSOR_MOVING_TIME, 1)
+        moving_time = activity.get(CONF_SENSOR_MOVING_TIME, 0)
+
+        if distance == 0 or moving_time == 0:
+            return 0.0
 
         speed = (distance / 1000) / (moving_time / 3600)  # km/h
         is_metric = self._is_metric()
@@ -1681,7 +1687,10 @@ class StravaRecentActivityMetricSensor(StravaRecentActivityAttributeSensor):
     def _calculate_speed(self, activity):
         """Calculate speed for the activity."""
         distance = activity.get(CONF_SENSOR_DISTANCE, 0)
-        moving_time = activity.get(CONF_SENSOR_MOVING_TIME, 1)
+        moving_time = activity.get(CONF_SENSOR_MOVING_TIME, 0)
+
+        if distance == 0 or moving_time == 0:
+            return 0.0
 
         speed = (distance / 1000) / (moving_time / 3600)
         is_metric = self._is_metric()

--- a/tests/custom_components/ha_strava/test_activity_attribute_sensors.py
+++ b/tests/custom_components/ha_strava/test_activity_attribute_sensors.py
@@ -25,6 +25,7 @@ from custom_components.ha_strava.sensor import (
     StravaActivityDateSensor,
     StravaActivityDeviceInfoSensor,
     StravaActivityMetricSensor,
+    StravaRecentActivityMetricSensor,
 )
 
 
@@ -513,6 +514,40 @@ class TestStravaActivityMetricSensor:
         assert value is not None
         assert isinstance(value, (int, float))
 
+    def test_speed_calculation_zero_moving_time(self):
+        """Test speed calculation returns 0.0 instead of raising ZeroDivisionError.
+
+        Regression test: activities with moving_time=0 (e.g. manually logged
+        activities) previously crashed entity setup with a ZeroDivisionError.
+        """
+        coordinator = MagicMock()
+        coordinator.data = {
+            "activities": [
+                {
+                    "id": 1,
+                    "type": "Run",
+                    "sport_type": "Run",
+                    "distance": 0.0,
+                    "moving_time": 0,
+                },
+            ],
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+        coordinator.entry = MagicMock()
+        mock_hass = MagicMock()
+        mock_hass.config.units = METRIC_SYSTEM
+        coordinator.hass = mock_hass
+
+        sensor = StravaActivityMetricSensor(
+            coordinator=coordinator,
+            activity_type="Run",
+            metric_type=CONF_SENSOR_SPEED,
+            athlete_id="12345",
+        )
+        sensor.hass = mock_hass
+
+        assert sensor.native_value == 0.0
+
     def test_unit_of_measurement_distance(self):
         """Test unit of measurement for distance sensor."""
         coordinator = MagicMock()
@@ -830,3 +865,39 @@ class TestStravaActivityMetricSensor:
 
         state = sensor.native_value
         assert state is None
+
+
+class TestStravaRecentActivityMetricSensorSpeed:
+    """Test StravaRecentActivityMetricSensor speed calculation."""
+
+    def test_speed_calculation_zero_moving_time(self):
+        """Test speed calculation returns 0.0 instead of raising ZeroDivisionError.
+
+        Regression test: activities with moving_time=0 (e.g. manually logged
+        activities) previously crashed entity setup with a ZeroDivisionError.
+        """
+        coordinator = MagicMock()
+        coordinator.data = {
+            "activities": [
+                {
+                    "id": 1,
+                    "type": "Run",
+                    "distance": 0.0,
+                    "moving_time": 0,
+                },
+            ],
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+        coordinator.entry = MagicMock()
+        mock_hass = MagicMock()
+        mock_hass.config.units = METRIC_SYSTEM
+        coordinator.hass = mock_hass
+
+        sensor = StravaRecentActivityMetricSensor(
+            coordinator=coordinator,
+            metric_type=CONF_SENSOR_SPEED,
+            athlete_id="12345",
+        )
+        sensor.hass = mock_hass
+
+        assert sensor.native_value == 0.0


### PR DESCRIPTION
## Summary
- Fixes a crash in speed sensor entity setup for activities with `moving_time=0` (e.g. manually logged activities)
- `_calculate_speed` defaulted `moving_time` to `1` only when the key was missing, not when present but `0` — now guards explicitly and returns `0.0`, matching the existing `_calculate_pace` behavior
- Applied the same fix to all three duplicated `_calculate_speed` implementations (`StravaActivityTypeSensor`, `StravaActivityMetricSensor`, `StravaRecentActivityMetricSensor`)