### PR TITLE
feat: drop Strava/athlete prefix from entity names

### DIFF
--- a/custom_components/ha_strava/button.py
+++ b/custom_components/ha_strava/button.py
@@ -83,6 +83,7 @@ async def async_setup_entry(
 
 
 class StravaActivityRefreshButton(CoordinatorEntity, ButtonEntity):
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
@@ -144,6 +145,7 @@ class StravaActivityRefreshButton(CoordinatorEntity, ButtonEntity):
 
 
 class StravaRecentActivityRefreshButton(CoordinatorEntity, ButtonEntity):
+    _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(

--- a/custom_components/ha_strava/camera.py
+++ b/custom_components/ha_strava/camera.py
@@ -82,6 +82,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class UrlCam(CoordinatorEntity, Camera):
     """A camera that cycles through a list of image URLs."""
 
+    _attr_has_entity_name = True
     _attr_should_poll = False
 
     def __init__(
@@ -98,7 +99,9 @@ class UrlCam(CoordinatorEntity, Camera):
         self._athlete_id = athlete_id
         self._athlete_name = get_athlete_name_from_title(self.coordinator.entry.title)
         self._attr_unique_id = f"strava_{athlete_id}_photos"
-        self._attr_name = generate_device_name(self._athlete_name, "Photos")
+        # None makes this the device's primary entity: HA uses the device
+        # name alone instead of concatenating an entity name onto it.
+        self._attr_name = None
         self._store = Store(
             hass,
             STORAGE_VERSION,

--- a/custom_components/ha_strava/const.py
+++ b/custom_components/ha_strava/const.py
@@ -550,18 +550,13 @@ def generate_sensor_id(athlete_id: str, activity_type: str, sensor_type: str) ->
     return f"strava_{athlete_id}_{activity_type}_{sensor_type}"
 
 
-def generate_sensor_name(
-    athlete_name: str, activity_type: str, sensor_type: str
-) -> str:
-    """Generate standardized sensor name."""
+def generate_sensor_name(sensor_type: str) -> str:
+    """Generate standardized sensor name (short form, for use with has_entity_name)."""
     # Special case for calories sensor
     if sensor_type == "kcal":
-        formatted_sensor = "Calories"
-    else:
-        # Format sensor type for display (replace underscores with spaces and title case)
-        formatted_sensor = sensor_type.replace("_", " ").title()
-
-    return f"Strava {athlete_name} {activity_type.title()} {formatted_sensor}"
+        return "Calories"
+    # Format sensor type for display (replace underscores with spaces and title case)
+    return sensor_type.replace("_", " ").title()
 
 
 def generate_recent_activity_sensor_id(
@@ -573,22 +568,13 @@ def generate_recent_activity_sensor_id(
     return f"strava_{athlete_id}_recent_{activity_index + 1}_{sensor_type}"
 
 
-def generate_recent_activity_sensor_name(
-    athlete_name: str, sensor_type: str, activity_index: int = 0
-) -> str:
-    """Generate standardized recent activity sensor name."""
+def generate_recent_activity_sensor_name(sensor_type: str) -> str:
+    """Generate standardized recent activity sensor name (short form, for use with has_entity_name)."""
     # Special case for calories sensor
     if sensor_type == "kcal":
-        formatted_sensor = "Calories"
-    else:
-        # Format sensor type for display (replace underscores with spaces and title case)
-        formatted_sensor = sensor_type.replace("_", " ").title()
-
-    if activity_index == 0:
-        return f"Strava {athlete_name} Recent Activity {formatted_sensor}"
-    return (
-        f"Strava {athlete_name} Recent Activity {activity_index + 1} {formatted_sensor}"
-    )
+        return "Calories"
+    # Format sensor type for display (replace underscores with spaces and title case)
+    return sensor_type.replace("_", " ").title()
 
 
 def generate_gear_device_id(athlete_id: str, gear_id: str) -> str:
@@ -606,12 +592,9 @@ def generate_gear_sensor_id(athlete_id: str, gear_id: str, sensor_type: str) -> 
     return f"strava_{athlete_id}_gear_{gear_id}_{sensor_type}"
 
 
-def generate_gear_sensor_name(
-    athlete_name: str, gear_name: str, sensor_type: str
-) -> str:
-    """Generate standardized gear sensor name."""
-    formatted_sensor = sensor_type.replace("_", " ").title()
-    return f"Strava {athlete_name} {gear_name} {formatted_sensor}"
+def generate_gear_sensor_name(sensor_type: str) -> str:
+    """Generate standardized gear sensor name (short form, for use with has_entity_name)."""
+    return sensor_type.replace("_", " ").title()
 
 
 def normalize_activity_type(activity_type: str) -> str:

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.3.2"
+  "version": "4.4.0"
 }

--- a/custom_components/ha_strava/sensor.py
+++ b/custom_components/ha_strava/sensor.py
@@ -305,6 +305,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class StravaSummaryStatsSensor(CoordinatorEntity, SensorEntity):
     """A sensor for Strava summary statistics."""
 
+    _attr_has_entity_name = True
     _attr_state_class = SensorStateClass.TOTAL
 
     def __init__(
@@ -507,12 +508,12 @@ class StravaSummaryStatsSensor(CoordinatorEntity, SensorEntity):
             activity_type = parts[-2]
             period = parts[0]
             formatted_sensor = self._metric_key.replace("_", " ").title()
-            return f"Strava {self._athlete_name} Stats {period.title()} {activity_type.title()} {formatted_sensor}"
+            return f"{period.title()} {activity_type.title()} {formatted_sensor}"
         elif self._api_key in ["biggest_ride_distance", "biggest_climb_elevation_gain"]:
             formatted_sensor = self._metric_key.replace("_", " ").title()
-            return f"Strava {self._athlete_name} Stats {formatted_sensor}"
+            return formatted_sensor
         else:
-            return f"Strava {self._athlete_name} Stats {self._display_name}"
+            return self._display_name
 
     @property
     def extra_state_attributes(self):
@@ -574,6 +575,7 @@ class StravaSummaryStatsSensor(CoordinatorEntity, SensorEntity):
 class StravaActivityTypeSensor(CoordinatorEntity, SensorEntity):
     """A sensor for specific activity type with latest activity data."""
 
+    _attr_has_entity_name = True
     _attr_state_class = None
     _attr_device_class = None
 
@@ -643,8 +645,12 @@ class StravaActivityTypeSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def name(self):
-        """Return the name of the sensor."""
-        return f"Strava {self._athlete_name} {format_activity_type_display(self._activity_type)}"
+        """Return the name of the sensor.
+
+        None makes this the device's primary entity: HA uses the device
+        name alone instead of concatenating an entity name onto it.
+        """
+        return None
 
     @property
     def extra_state_attributes(self):
@@ -735,6 +741,8 @@ class StravaActivityTypeSensor(CoordinatorEntity, SensorEntity):
 class StravaActivityAttributeSensor(CoordinatorEntity, SensorEntity):
     """Base class for individual activity attribute sensors."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: StravaDataUpdateCoordinator,
@@ -809,11 +817,7 @@ class StravaActivityAttributeSensor(CoordinatorEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return generate_sensor_name(
-            self._athlete_name,
-            format_activity_type_display(self._activity_type),
-            self._attribute_type,
-        )
+        return generate_sensor_name(self._attribute_type)
 
     def _get_value_or_unavailable(self, value):
         """Return the value or None if None, blank, or -1."""
@@ -1203,6 +1207,7 @@ class StravaActivityMetricSensor(StravaActivityAttributeSensor):
 class StravaRecentActivitySensor(CoordinatorEntity, SensorEntity):
     """A sensor for the most recent activity across all activity types."""
 
+    _attr_has_entity_name = True
     _attr_state_class = None
     _attr_device_class = None
 
@@ -1278,10 +1283,12 @@ class StravaRecentActivitySensor(CoordinatorEntity, SensorEntity):
 
     @property
     def name(self):
-        """Return the name of the sensor."""
-        return generate_recent_activity_device_name(
-            self._athlete_name, self._activity_index
-        )
+        """Return the name of the sensor.
+
+        None makes this the device's primary entity: HA uses the device
+        name alone instead of concatenating an entity name onto it.
+        """
+        return None
 
     @property
     def extra_state_attributes(self):
@@ -1311,6 +1318,8 @@ class StravaRecentActivitySensor(CoordinatorEntity, SensorEntity):
 
 class StravaRecentActivityAttributeSensor(CoordinatorEntity, SensorEntity):
     """Base class for individual recent activity attribute sensors."""
+
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -1385,11 +1394,7 @@ class StravaRecentActivityAttributeSensor(CoordinatorEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return generate_recent_activity_sensor_name(
-            self._athlete_name,
-            self._attribute_type,
-            self._activity_index,
-        )
+        return generate_recent_activity_sensor_name(self._attribute_type)
 
     def _get_value_or_unavailable(self, value):
         """Return the value or None if None, blank, or -1."""
@@ -1745,6 +1750,7 @@ class StravaRecentActivityMetricSensor(StravaRecentActivityAttributeSensor):
 class StravaGearNameSensor(CoordinatorEntity, SensorEntity):
     """Sensor for gear name with attributes."""
 
+    _attr_has_entity_name = True
     _attr_state_class = None
     _attr_device_class = None
 
@@ -1810,14 +1816,12 @@ class StravaGearNameSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def name(self):
-        """Return the name of the sensor."""
-        gear_data = self._gear_data
-        gear_name = (
-            gear_data.get("name", f"Gear {self._gear_id}")
-            if gear_data
-            else f"Gear {self._gear_id}"
-        )
-        return generate_gear_sensor_name(self._athlete_name, gear_name, "name")
+        """Return the name of the sensor.
+
+        None makes this the device's primary entity: HA uses the device
+        name alone instead of concatenating an entity name onto it.
+        """
+        return None
 
     @property
     def extra_state_attributes(self):
@@ -1842,6 +1846,7 @@ class StravaGearNameSensor(CoordinatorEntity, SensorEntity):
 class StravaGearDistanceSensor(CoordinatorEntity, SensorEntity):
     """Sensor for gear distance."""
 
+    _attr_has_entity_name = True
     _attr_state_class = SensorStateClass.TOTAL
     _attr_device_class = DEVICE_CLASS_DISTANCE
 
@@ -1927,13 +1932,7 @@ class StravaGearDistanceSensor(CoordinatorEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        gear_data = self._gear_data
-        gear_name = (
-            gear_data.get("name", f"Gear {self._gear_id}")
-            if gear_data
-            else f"Gear {self._gear_id}"
-        )
-        return generate_gear_sensor_name(self._athlete_name, gear_name, "distance")
+        return generate_gear_sensor_name("distance")
 
     def _is_metric(self):
         """Determine if the user has configured metric units."""

--- a/tests/custom_components/ha_strava/test_activity_attribute_sensors.py
+++ b/tests/custom_components/ha_strava/test_activity_attribute_sensors.py
@@ -169,7 +169,8 @@ class TestStravaActivityAttributeSensor:
             athlete_id="12345",
         )
 
-        assert sensor.name == "Strava Test User Run Test Attribute"
+        assert sensor.name == "Test Attribute"
+        assert sensor.has_entity_name is True
 
 
 class TestStravaActivityDeviceInfoSensor:

--- a/tests/custom_components/ha_strava/test_activity_type_sensors.py
+++ b/tests/custom_components/ha_strava/test_activity_type_sensors.py
@@ -39,11 +39,10 @@ class TestStravaActivityTypeSensor:
         for i, sensor in enumerate(sensors):
             activity_type = SUPPORTED_ACTIVITY_TYPES[i]
             assert sensor._activity_type == activity_type
-            # Format activity type for display (handle camelCase)
-            import re
-
-            formatted_activity_type = re.sub(r"(?<=[a-z])(?=[A-Z])", " ", activity_type)
-            assert sensor.name == f"Strava Test User {formatted_activity_type}"
+            # name is None: this sensor is the device's primary entity, so
+            # HA displays the device name alone via has_entity_name
+            assert sensor.name is None
+            assert sensor.has_entity_name is True
             assert sensor.unique_id == f"strava_12345_{activity_type.lower()}"
 
     def test_sensor_creation_selected_activity_types(self, mock_config_entry):
@@ -75,7 +74,8 @@ class TestStravaActivityTypeSensor:
         # Verify each sensor has correct properties
         for sensor in sensors:
             assert sensor._activity_type in selected_types
-            assert sensor.name.startswith("Strava ")
+            assert sensor.name is None
+            assert sensor.has_entity_name is True
             assert sensor.unique_id.startswith("strava_12345_")
 
     def test_sensor_attributes_with_activity_data(self, mock_strava_activities):

--- a/tests/custom_components/ha_strava/test_constants_multiple_activities.py
+++ b/tests/custom_components/ha_strava/test_constants_multiple_activities.py
@@ -1,5 +1,7 @@
 """Test constants and helper functions for multiple recent activity devices."""
 
+import pytest
+
 from custom_components.ha_strava.const import (
     CONF_NUM_RECENT_ACTIVITIES,
     CONF_NUM_RECENT_ACTIVITIES_DEFAULT,
@@ -224,40 +226,15 @@ class TestGenerateRecentActivitySensorId:
 
 
 class TestGenerateRecentActivitySensorName:
-    """Test generate_recent_activity_sensor_name function."""
+    """Test generate_recent_activity_sensor_name function.
 
-    def test_default_index_zero(self):
-        """Test sensor name generation with default index (0)."""
-        athlete_name = "John Doe"
-        sensor_type = "title"
-        sensor_name = generate_recent_activity_sensor_name(athlete_name, sensor_type)
-        assert sensor_name == "Strava John Doe Recent Activity Title"
-
-    def test_explicit_index_zero(self):
-        """Test sensor name generation with explicit index 0."""
-        athlete_name = "John Doe"
-        sensor_type = "title"
-        sensor_name = generate_recent_activity_sensor_name(athlete_name, sensor_type, 0)
-        assert sensor_name == "Strava John Doe Recent Activity Title"
-
-    def test_index_one(self):
-        """Test sensor name generation with index 1."""
-        athlete_name = "John Doe"
-        sensor_type = "title"
-        sensor_name = generate_recent_activity_sensor_name(athlete_name, sensor_type, 1)
-        assert sensor_name == "Strava John Doe Recent Activity 2 Title"
-
-    def test_index_two(self):
-        """Test sensor name generation with index 2."""
-        athlete_name = "John Doe"
-        sensor_type = "distance"
-        sensor_name = generate_recent_activity_sensor_name(athlete_name, sensor_type, 2)
-        assert sensor_name == "Strava John Doe Recent Activity 3 Distance"
+    The function returns a short entity name only (no athlete/device
+    prefix or activity index) — HA composes the full displayed name by
+    prefixing the device name via has_entity_name.
+    """
 
     def test_sensor_type_formatting(self):
         """Test that sensor types are properly formatted for display."""
-        athlete_name = "Test User"
-
         test_cases = [
             ("title", "Title"),
             ("distance", "Distance"),
@@ -269,72 +246,12 @@ class TestGenerateRecentActivitySensorName:
         ]
 
         for sensor_type, expected_formatted in test_cases:
-            # Test index 0
-            sensor_name = generate_recent_activity_sensor_name(
-                athlete_name, sensor_type, 0
-            )
-            assert (
-                sensor_name == f"Strava Test User Recent Activity {expected_formatted}"
-            )
-
-            # Test index 1
-            sensor_name = generate_recent_activity_sensor_name(
-                athlete_name, sensor_type, 1
-            )
-            assert (
-                sensor_name
-                == f"Strava Test User Recent Activity 2 {expected_formatted}"
-            )
+            sensor_name = generate_recent_activity_sensor_name(sensor_type)
+            assert sensor_name == expected_formatted
 
     def test_kcal_sensor_type_formatting(self):
         """Test that 'kcal' sensor type is properly formatted as 'Calories'."""
-        athlete_name = "Test User"
-
-        # Test index 0 - should show "Calories" not "Kcal"
-        sensor_name = generate_recent_activity_sensor_name(athlete_name, "kcal", 0)
-        assert sensor_name == "Strava Test User Recent Activity Calories"
-
-        # Test index 1 - should show "Calories" not "Kcal"
-        sensor_name = generate_recent_activity_sensor_name(athlete_name, "kcal", 1)
-        assert sensor_name == "Strava Test User Recent Activity 2 Calories"
-
-        # Test index 2 - should show "Calories" not "Kcal"
-        sensor_name = generate_recent_activity_sensor_name(athlete_name, "kcal", 2)
-        assert sensor_name == "Strava Test User Recent Activity 3 Calories"
-
-        # Test index 9 (max) - should show "Calories" not "Kcal"
-        sensor_name = generate_recent_activity_sensor_name(athlete_name, "kcal", 9)
-        assert sensor_name == "Strava Test User Recent Activity 10 Calories"
-
-    def test_different_athlete_names(self):
-        """Test sensor name generation with different athlete names."""
-        sensor_type = "test_sensor"
-
-        # Test with single name
-        sensor_name = generate_recent_activity_sensor_name("Alice", sensor_type, 1)
-        assert sensor_name == "Strava Alice Recent Activity 2 Test Sensor"
-
-        # Test with multiple names
-        sensor_name = generate_recent_activity_sensor_name("Bob Smith", sensor_type, 2)
-        assert sensor_name == "Strava Bob Smith Recent Activity 3 Test Sensor"
-
-    def test_index_numbering_starts_at_two(self):
-        """Test that index numbering starts at 2 (index 1 -> 2, index 2 -> 3, etc.)."""
-        athlete_name = "Test User"
-        sensor_type = "test_sensor"
-
-        for i in range(10):
-            sensor_name = generate_recent_activity_sensor_name(
-                athlete_name, sensor_type, i
-            )
-            if i == 0:
-                assert sensor_name == "Strava Test User Recent Activity Test Sensor"
-            else:
-                expected_number = i + 1
-                assert (
-                    sensor_name
-                    == f"Strava Test User Recent Activity {expected_number} Test Sensor"
-                )
+        assert generate_recent_activity_sensor_name("kcal") == "Calories"
 
 
 class TestEdgeCases:
@@ -380,8 +297,8 @@ class TestEdgeCases:
         sensor_id = generate_recent_activity_sensor_id("12345", "", 1)
         assert sensor_id == "strava_12345_recent_2_"
 
-        sensor_name = generate_recent_activity_sensor_name("Test User", "", 1)
-        assert sensor_name == "Strava Test User Recent Activity 2 "
+        sensor_name = generate_recent_activity_sensor_name("")
+        assert sensor_name == ""
 
     def test_none_values(self):
         """Test behavior with None values."""
@@ -397,6 +314,6 @@ class TestEdgeCases:
         sensor_id = generate_recent_activity_sensor_id("12345", None, 1)
         assert sensor_id == "strava_12345_recent_2_None"
 
-        # Test with None athlete_name for sensor
-        sensor_name = generate_recent_activity_sensor_name(None, "test", 1)
-        assert sensor_name == "Strava None Recent Activity 2 Test"
+        # None sensor_type raises, same as before this refactor
+        with pytest.raises(AttributeError):
+            generate_recent_activity_sensor_name(None)

--- a/tests/custom_components/ha_strava/test_gear_sensors.py
+++ b/tests/custom_components/ha_strava/test_gear_sensors.py
@@ -109,12 +109,13 @@ class TestStravaGearNameSensor:
         assert sensor.native_value is None
 
     def test_name_property(self):
-        """name property returns a human-readable name using gear's own name."""
+        """name is None: this sensor is the gear device's primary entity."""
         coordinator = _make_coordinator([GEAR_BIKE])
         sensor = StravaGearNameSensor(
             coordinator, gear_id="b111111", athlete_id="12345"
         )
-        assert sensor.name == "Strava Test User CGR SL Name"
+        assert sensor.name is None
+        assert sensor.has_entity_name is True
 
     def test_device_info_uses_gear_id(self):
         """device_info identifiers must be based on gear ID, not index."""

--- a/tests/custom_components/ha_strava/test_init.py
+++ b/tests/custom_components/ha_strava/test_init.py
@@ -141,9 +141,7 @@ class TestWebhookSubscription:
         with patch(
             "custom_components.ha_strava.get_url", return_value="https://example.com"
         ):
-            aioresponses_mock.get(
-                "https://example.com/api/strava/webhook", status=200
-            )
+            aioresponses_mock.get("https://example.com/api/strava/webhook", status=200)
             # Mock existing subscriptions
             aioresponses_mock.get(
                 "https://www.strava.com/api/v3/push_subscriptions"
@@ -193,9 +191,7 @@ class TestWebhookSubscription:
             "async_update_entry",
             wraps=hass.config_entries.async_update_entry,
         ) as mock_update:
-            aioresponses_mock.get(
-                "https://example.com/api/strava/webhook", status=200
-            )
+            aioresponses_mock.get("https://example.com/api/strava/webhook", status=200)
             push_subs_url = (
                 "https://www.strava.com/api/v3/push_subscriptions"
                 "?client_id=test_client_id&client_secret=test_client_secret"
@@ -227,9 +223,7 @@ class TestWebhookSubscription:
             "async_update_entry",
             wraps=hass.config_entries.async_update_entry,
         ) as mock_update:
-            aioresponses_mock.get(
-                "https://example.com/api/strava/webhook", status=200
-            )
+            aioresponses_mock.get("https://example.com/api/strava/webhook", status=200)
             push_subs_url = (
                 "https://www.strava.com/api/v3/push_subscriptions"
                 "?client_id=test_client_id&client_secret=test_client_secret"
@@ -260,9 +254,7 @@ class TestWebhookSubscription:
         with patch(
             "custom_components.ha_strava.get_url", return_value="https://example.com"
         ):
-            aioresponses_mock.get(
-                "https://example.com/api/strava/webhook", status=200
-            )
+            aioresponses_mock.get("https://example.com/api/strava/webhook", status=200)
             aioresponses_mock.get(
                 "https://www.strava.com/api/v3/push_subscriptions",
                 payload=[
@@ -297,9 +289,7 @@ class TestWebhookSubscription:
             "async_update_entry",
             wraps=hass.config_entries.async_update_entry,
         ) as mock_update:
-            aioresponses_mock.get(
-                "https://example.com/api/strava/webhook", status=200
-            )
+            aioresponses_mock.get("https://example.com/api/strava/webhook", status=200)
             aioresponses_mock.get(
                 "https://www.strava.com/api/v3/push_subscriptions",
                 payload=[{"id": 1}],
@@ -328,9 +318,7 @@ class TestWebhookSubscription:
         with patch(
             "custom_components.ha_strava.get_url", return_value="https://example.com"
         ):
-            aioresponses_mock.get(
-                "https://example.com/api/strava/webhook", status=200
-            )
+            aioresponses_mock.get("https://example.com/api/strava/webhook", status=200)
             aioresponses_mock.get(
                 "https://www.strava.com/api/v3/push_subscriptions",
                 payload=[
@@ -373,9 +361,7 @@ class TestWebhookSubscription:
             "async_update_entry",
             wraps=hass.config_entries.async_update_entry,
         ) as mock_update:
-            aioresponses_mock.get(
-                "https://example.com/api/strava/webhook", status=200
-            )
+            aioresponses_mock.get("https://example.com/api/strava/webhook", status=200)
             aioresponses_mock.get(
                 "https://www.strava.com/api/v3/push_subscriptions",
                 status=500,

--- a/tests/custom_components/ha_strava/test_multi_athlete_naming.py
+++ b/tests/custom_components/ha_strava/test_multi_athlete_naming.py
@@ -1,0 +1,169 @@
+"""Test that entity naming/grouping stays isolated per athlete.
+
+Sensor `name` properties were shortened to drop the "Strava {athlete}"
+prefix, relying on `has_entity_name` so Home Assistant composes the
+displayed name from the device name. This module verifies that removing
+the prefix from entity names does not collapse grouping or identity
+across multiple athlete config entries: unique_id and device identifiers
+must still be athlete-scoped even though the entity `name` text is now
+identical for equivalent sensors across athletes.
+"""
+
+from unittest.mock import MagicMock
+
+from custom_components.ha_strava.const import DOMAIN
+from custom_components.ha_strava.sensor import (
+    StravaActivityAttributeSensor,
+    StravaActivityTypeSensor,
+    StravaGearDistanceSensor,
+    StravaGearNameSensor,
+    StravaRecentActivityAttributeSensor,
+    StravaRecentActivitySensor,
+)
+
+
+def _make_coordinator(athlete_title, gear_list=None):
+    coordinator = MagicMock()
+    coordinator.data = {"activities": [], "gear": gear_list or []}
+    coordinator.entry = MagicMock()
+    coordinator.entry.title = athlete_title
+    coordinator.entry.options = {}
+    coordinator.entry.data = {}
+    return coordinator
+
+
+ATHLETE_A = ("11111", "Strava: Alice Athlete")
+ATHLETE_B = ("22222", "Strava: Bob Athlete")
+
+
+class TestActivityTypeSensorIsolation:
+    """Two athletes' same-activity-type sensors share a display name but not identity."""
+
+    def test_same_name_different_unique_id_and_device(self):
+        coord_a = _make_coordinator(ATHLETE_A[1])
+        coord_b = _make_coordinator(ATHLETE_B[1])
+
+        sensor_a = StravaActivityTypeSensor(
+            coordinator=coord_a, activity_type="Run", athlete_id=ATHLETE_A[0]
+        )
+        sensor_b = StravaActivityTypeSensor(
+            coordinator=coord_b, activity_type="Run", athlete_id=ATHLETE_B[0]
+        )
+
+        # Entity name text is identical (both None -> device name only)...
+        assert sensor_a.name == sensor_b.name is None
+
+        # ...but unique_id and device identifiers are athlete-scoped.
+        assert sensor_a.unique_id != sensor_b.unique_id
+        assert sensor_a.unique_id == "strava_11111_run"
+        assert sensor_b.unique_id == "strava_22222_run"
+
+        assert (
+            sensor_a.device_info["identifiers"] != sensor_b.device_info["identifiers"]
+        )
+        assert (DOMAIN, "strava_11111_run") in sensor_a.device_info["identifiers"]
+        assert (DOMAIN, "strava_22222_run") in sensor_b.device_info["identifiers"]
+
+        # Device names still carry the athlete name, so the UI stays
+        # distinguishable even though entity names are athlete-agnostic.
+        assert sensor_a.device_info["name"] != sensor_b.device_info["name"]
+        assert "Alice Athlete" in sensor_a.device_info["name"]
+        assert "Bob Athlete" in sensor_b.device_info["name"]
+
+
+class TestActivityAttributeSensorIsolation:
+    """Two athletes' equivalent attribute sensors share a name but differ in identity."""
+
+    def test_same_name_different_unique_id_and_device(self):
+        coord_a = _make_coordinator(ATHLETE_A[1])
+        coord_b = _make_coordinator(ATHLETE_B[1])
+
+        sensor_a = StravaActivityAttributeSensor(
+            coordinator=coord_a,
+            activity_type="Run",
+            attribute_type="distance",
+            athlete_id=ATHLETE_A[0],
+        )
+        sensor_b = StravaActivityAttributeSensor(
+            coordinator=coord_b,
+            activity_type="Run",
+            attribute_type="distance",
+            athlete_id=ATHLETE_B[0],
+        )
+
+        assert sensor_a.name == sensor_b.name == "Distance"
+        assert sensor_a.has_entity_name is True
+
+        assert sensor_a.unique_id != sensor_b.unique_id
+        assert sensor_a.unique_id == "strava_11111_run_distance"
+        assert sensor_b.unique_id == "strava_22222_run_distance"
+
+        assert (
+            sensor_a.device_info["identifiers"] != sensor_b.device_info["identifiers"]
+        )
+
+
+class TestRecentActivitySensorIsolation:
+    """Two athletes' recent-activity devices/sensors stay isolated."""
+
+    def test_same_name_different_unique_id_and_device(self):
+        coord_a = _make_coordinator(ATHLETE_A[1])
+        coord_b = _make_coordinator(ATHLETE_B[1])
+
+        sensor_a = StravaRecentActivitySensor(
+            coordinator=coord_a, athlete_id=ATHLETE_A[0]
+        )
+        sensor_b = StravaRecentActivitySensor(
+            coordinator=coord_b, athlete_id=ATHLETE_B[0]
+        )
+
+        assert sensor_a.name == sensor_b.name is None
+        assert sensor_a.unique_id != sensor_b.unique_id
+        assert (
+            sensor_a.device_info["identifiers"] != sensor_b.device_info["identifiers"]
+        )
+
+        attr_a = StravaRecentActivityAttributeSensor(
+            coordinator=coord_a, attribute_type="pace", athlete_id=ATHLETE_A[0]
+        )
+        attr_b = StravaRecentActivityAttributeSensor(
+            coordinator=coord_b, attribute_type="pace", athlete_id=ATHLETE_B[0]
+        )
+
+        assert attr_a.name == attr_b.name == "Pace"
+        assert attr_a.unique_id != attr_b.unique_id
+        assert attr_a.device_info["identifiers"] != attr_b.device_info["identifiers"]
+
+
+class TestGearSensorIsolation:
+    """Two athletes with identically named gear stay isolated by athlete_id + gear_id."""
+
+    GEAR = {"id": "b111111", "name": "Road Bike", "distance": 1000.0}
+
+    def test_same_gear_name_different_unique_id_and_device(self):
+        coord_a = _make_coordinator(ATHLETE_A[1], gear_list=[self.GEAR])
+        coord_b = _make_coordinator(ATHLETE_B[1], gear_list=[self.GEAR])
+
+        name_a = StravaGearNameSensor(
+            coord_a, gear_id="b111111", athlete_id=ATHLETE_A[0]
+        )
+        name_b = StravaGearNameSensor(
+            coord_b, gear_id="b111111", athlete_id=ATHLETE_B[0]
+        )
+
+        # Same gear name/id on both athletes, but device identifiers and
+        # unique_id remain athlete-scoped.
+        assert name_a.name == name_b.name is None
+        assert name_a.unique_id != name_b.unique_id
+        assert name_a.device_info["identifiers"] != name_b.device_info["identifiers"]
+
+        dist_a = StravaGearDistanceSensor(
+            coord_a, gear_id="b111111", athlete_id=ATHLETE_A[0]
+        )
+        dist_b = StravaGearDistanceSensor(
+            coord_b, gear_id="b111111", athlete_id=ATHLETE_B[0]
+        )
+
+        assert dist_a.name == dist_b.name == "Distance"
+        assert dist_a.unique_id != dist_b.unique_id
+        assert dist_a.device_info["identifiers"] != dist_b.device_info["identifiers"]

--- a/tests/custom_components/ha_strava/test_multiple_recent_activities.py
+++ b/tests/custom_components/ha_strava/test_multiple_recent_activities.py
@@ -81,26 +81,8 @@ class TestNamingConventions:
         assert sensor_id_2 == "strava_12345_recent_3_title"
 
     def test_generate_recent_activity_sensor_name(self):
-        """Test sensor name generation for different activity indices."""
-        athlete_name = "John Doe"
-        sensor_type = "distance"
-
-        # Test index 0 (backward compatibility)
-        sensor_name_0 = generate_recent_activity_sensor_name(
-            athlete_name, sensor_type, 0
-        )
-        assert sensor_name_0 == "Strava John Doe Recent Activity Distance"
-
-        # Test index 1+ (numbered)
-        sensor_name_1 = generate_recent_activity_sensor_name(
-            athlete_name, sensor_type, 1
-        )
-        assert sensor_name_1 == "Strava John Doe Recent Activity 2 Distance"
-
-        sensor_name_2 = generate_recent_activity_sensor_name(
-            athlete_name, sensor_type, 2
-        )
-        assert sensor_name_2 == "Strava John Doe Recent Activity 3 Distance"
+        """Sensor name is short-form only; HA composes it with the device name."""
+        assert generate_recent_activity_sensor_name("distance") == "Distance"
 
 
 class TestStravaRecentActivitySensor:
@@ -127,7 +109,8 @@ class TestStravaRecentActivitySensor:
         )
 
         assert sensor._activity_index == 0
-        assert sensor.name == "Strava Test User Recent Activity"
+        assert sensor.name is None
+        assert sensor.has_entity_name is True
         assert sensor.unique_id == "strava_12345_recent_recent"
 
     @pytest.mark.asyncio
@@ -151,7 +134,8 @@ class TestStravaRecentActivitySensor:
         )
 
         assert sensor._activity_index == 1
-        assert sensor.name == "Strava Test User Recent Activity 2"
+        assert sensor.name is None
+        assert sensor.has_entity_name is True
         assert sensor.unique_id == "strava_12345_recent_2_recent"
 
     def test_latest_activity_property(self):
@@ -232,7 +216,8 @@ class TestStravaRecentActivityAttributeSensor:
 
         assert sensor._activity_index == 1
         assert sensor.unique_id == "strava_12345_recent_2_distance"
-        assert sensor.name == "Strava Test User Recent Activity 2 Distance"
+        assert sensor.name == "Distance"
+        assert sensor.has_entity_name is True
 
     def test_device_info_with_index(self):
         """Test device_info property includes correct index."""
@@ -402,11 +387,17 @@ class TestSensorSetupWithMultipleActivities:
         indices = [sensor._activity_index for sensor in recent_activity_sensors]
         assert sorted(indices) == [0, 1, 2]
 
-        # Check names
+        # Entity name is None (primary entity of its device); the
+        # distinguishing text lives in the device name instead.
         names = [sensor.name for sensor in recent_activity_sensors]
-        assert "Strava Test User Recent Activity" in names  # Index 0
-        assert "Strava Test User Recent Activity 2" in names  # Index 1
-        assert "Strava Test User Recent Activity 3" in names  # Index 2
+        assert names == [None, None, None]
+
+        device_names = [
+            sensor.device_info["name"] for sensor in recent_activity_sensors
+        ]
+        assert "Strava Test User Recent Activity" in device_names  # Index 0
+        assert "Strava Test User Recent Activity 2" in device_names  # Index 1
+        assert "Strava Test User Recent Activity 3" in device_names  # Index 2
 
     @pytest.mark.asyncio
     async def test_setup_with_max_recent_activities(self, hass: HomeAssistant):

--- a/tests/custom_components/ha_strava/test_sensor.py
+++ b/tests/custom_components/ha_strava/test_sensor.py
@@ -47,7 +47,8 @@ class TestStravaActivityTypeSensor:
         )
 
         assert sensor._activity_type == "Run"
-        assert sensor.name == "Strava Test User Run"
+        assert sensor.name is None
+        assert sensor.has_entity_name is True
         assert sensor.unique_id == "strava_12345_run"
 
     def test_sensor_state_with_activity(self, mock_strava_activities):
@@ -239,7 +240,8 @@ class TestStravaSummaryStatsSensor:
             athlete_id="12345",
         )
 
-        assert sensor.name == "Strava Test User Stats Recent Run Distance"
+        assert sensor.name == "Recent Run Distance"
+        assert sensor.has_entity_name is True
         assert sensor.unique_id == "strava_12345_stats_recent_run_totals_distance"
 
     def test_sensor_state_with_stats(self, mock_strava_stats):
@@ -622,7 +624,9 @@ class TestStravaSummaryStatsSensor:
         assert sensor._is_metric() is True
 
     @pytest.mark.asyncio
-    async def test_is_metric_options_takes_precedence_over_data(self, hass: HomeAssistant):
+    async def test_is_metric_options_takes_precedence_over_data(
+        self, hass: HomeAssistant
+    ):
         """Test _is_metric() prioritizes options over data when both are set."""
         summary_stats = {
             "ytd_run_totals": {
@@ -963,7 +967,8 @@ class TestStravaActivityGearSensor:
         )
 
         assert sensor._activity_type == "Ride"
-        assert sensor.name.startswith("Strava Test User Ride Gear Name")
+        assert sensor.name == "Gear Name"
+        assert sensor.has_entity_name is True
 
     def test_sensor_state_with_gear_data(self):
         """Test gear sensor state when gear data is available."""


### PR DESCRIPTION
## Summary
- Adopt `has_entity_name` across sensor, button, and camera entities so Home Assistant composes the displayed name from the device name, instead of every entity hardcoding "Strava {athlete}" into its own name
- Primary entities per device (main activity sensor, recent-activity sensor, gear name sensor) now return `name = None`, the standard HA pattern for a device's main entity
- `generate_sensor_name`, `generate_recent_activity_sensor_name`, `generate_gear_sensor_name` simplified to return short labels only (e.g. `"Distance"`) — device-name helpers are unchanged
- Fixes a pre-existing bug in `button.py`/`camera.py` where entities set a short `_attr_name` without `has_entity_name`, causing them to display with no device context
- Multi-athlete isolation is unaffected: every `unique_id` and `device_info["identifiers"]` still embeds `athlete_id` (and `gear_id` for gear), verified by a new isolation test covering two athletes with identically-named sensors/gear