### PR TITLE
fix: clear stale entity names after upgrade

### DIFF
--- a/custom_components/ha_strava/__init__.py
+++ b/custom_components/ha_strava/__init__.py
@@ -327,6 +327,26 @@ def _remove_legacy_gear_entries(hass: HomeAssistant, entry: ConfigEntry) -> None
             break
 
 
+def _migrate_entity_registry_names(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Clear stale original_name left over from before has_entity_name.
+
+    Entities registered before the switch to has_entity_name had their full
+    "Strava {athlete} ..." name stored as original_name in the entity
+    registry. That stored value doesn't update on its own when the entity's
+    name property changes on integration upgrade, so the old text keeps
+    showing in the UI unless it's explicitly cleared here to let HA fall
+    back to the current name property (or device name).
+
+    Only original_name (the integration-provided default) is touched; a
+    user-set name override is left untouched.
+    """
+    entity_registry = er_async_get(hass)
+    for entity in async_entries_for_config_entry(entity_registry, entry.entry_id):
+        if entity.original_name is None:
+            continue
+        entity_registry.async_update_entity(entity.entity_id, original_name=None)
+
+
 async def async_setup(
     hass: HomeAssistant, config: dict
 ):  # pylint: disable=unused-argument
@@ -345,6 +365,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     # Remove any gear entities/devices left over from the old index-based unique_id format
     _remove_legacy_gear_entries(hass, entry)
+
+    # Clear stale registry names left over from before has_entity_name
+    _migrate_entity_registry_names(hass, entry)
 
     # Set up webhook
     hass.http.register_view(StravaWebhookView(hass))

--- a/tests/custom_components/ha_strava/test_config_flow_entity_cleanup.py
+++ b/tests/custom_components/ha_strava/test_config_flow_entity_cleanup.py
@@ -765,3 +765,73 @@ class TestRemoveLegacyGearEntries:
 
         mock_er.async_remove.assert_not_called()
         mock_dr.async_remove_device.assert_not_called()
+
+
+class TestMigrateEntityRegistryNames:
+    """Test the _migrate_entity_registry_names helper called during async_setup_entry."""
+
+    @pytest.mark.asyncio
+    async def test_clears_stale_original_name(self, hass: HomeAssistant):
+        """Entities with a stored original_name have it cleared so the live name property applies."""
+        from custom_components.ha_strava import _migrate_entity_registry_names
+        from custom_components.ha_strava.const import DOMAIN
+
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id="12345",
+            data={CONF_CLIENT_ID: "cid", CONF_CLIENT_SECRET: "csec"},
+            title="Strava: Test User",
+        )
+
+        stale_entity = MagicMock()
+        stale_entity.entity_id = "sensor.strava_12345_recent_title"
+        stale_entity.original_name = "Strava Test User Recent Activity"
+
+        already_clean_entity = MagicMock()
+        already_clean_entity.entity_id = "sensor.strava_12345_distance"
+        already_clean_entity.original_name = None
+
+        mock_er = MagicMock()
+
+        with patch(
+            "custom_components.ha_strava.er_async_get",
+            return_value=mock_er,
+        ), patch(
+            "custom_components.ha_strava.async_entries_for_config_entry",
+            return_value=[stale_entity, already_clean_entity],
+        ):
+            _migrate_entity_registry_names(hass, config_entry)
+
+        mock_er.async_update_entity.assert_called_once_with(
+            "sensor.strava_12345_recent_title", original_name=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_no_stale_names(self, hass: HomeAssistant):
+        """No updates occur when all entities already have no original_name set."""
+        from custom_components.ha_strava import _migrate_entity_registry_names
+        from custom_components.ha_strava.const import DOMAIN
+
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id="12345",
+            data={CONF_CLIENT_ID: "cid", CONF_CLIENT_SECRET: "csec"},
+            title="Strava: Test User",
+        )
+
+        clean_entity = MagicMock()
+        clean_entity.entity_id = "sensor.strava_12345_distance"
+        clean_entity.original_name = None
+
+        mock_er = MagicMock()
+
+        with patch(
+            "custom_components.ha_strava.er_async_get",
+            return_value=mock_er,
+        ), patch(
+            "custom_components.ha_strava.async_entries_for_config_entry",
+            return_value=[clean_entity],
+        ):
+            _migrate_entity_registry_names(hass, config_entry)
+
+        mock_er.async_update_entity.assert_not_called()


### PR DESCRIPTION
## Summary
- Existing entities kept displaying the old "Strava {athlete} ..." name in the UI after upgrading to has_entity_name, because HA caches the original name in the entity registry and doesn't refresh it automatically
- Adds a one-time cleanup on setup that clears the stale `original_name` so HA falls back to the live name property, matching newly created entities
- User-set custom names are untouched — only the integration-provided default is cleared