### PR TITLE
fix: drop Strava/athlete prefix from device names

### DIFF
--- a/custom_components/ha_strava/const.py
+++ b/custom_components/ha_strava/const.py
@@ -524,9 +524,11 @@ def generate_device_id(athlete_id: str, device_type: str) -> str:
     return f"strava_{athlete_id}_{device_type}"
 
 
-def generate_device_name(athlete_name: str, device_type: str) -> str:
-    """Generate standardized device name."""
-    return f"Strava {athlete_name} {device_type.title()}"
+def generate_device_name(
+    athlete_name: str, device_type: str  # pylint: disable=unused-argument
+) -> str:
+    """Generate standardized device name (short form; athlete identity lives on the config entry)."""
+    return device_type.title()
 
 
 def generate_recent_activity_device_id(athlete_id: str, activity_index: int = 0) -> str:
@@ -537,12 +539,12 @@ def generate_recent_activity_device_id(athlete_id: str, activity_index: int = 0)
 
 
 def generate_recent_activity_device_name(
-    athlete_name: str, activity_index: int = 0
+    athlete_name: str, activity_index: int = 0  # pylint: disable=unused-argument
 ) -> str:
-    """Generate standardized recent activity device name."""
+    """Generate standardized recent activity device name (short form; athlete identity lives on the config entry)."""
     if activity_index == 0:
-        return f"Strava {athlete_name} Recent Activity"
-    return f"Strava {athlete_name} Recent Activity {activity_index + 1}"
+        return "Recent Activity"
+    return f"Recent Activity {activity_index + 1}"
 
 
 def generate_sensor_id(athlete_id: str, activity_type: str, sensor_type: str) -> str:
@@ -582,9 +584,11 @@ def generate_gear_device_id(athlete_id: str, gear_id: str) -> str:
     return f"strava_{athlete_id}_gear_{gear_id}"
 
 
-def generate_gear_device_name(athlete_name: str, gear_name: str) -> str:
-    """Generate standardized gear device name."""
-    return f"Strava {athlete_name} {gear_name}"
+def generate_gear_device_name(
+    athlete_name: str, gear_name: str  # pylint: disable=unused-argument
+) -> str:
+    """Generate standardized gear device name (short form; athlete identity lives on the config entry)."""
+    return gear_name
 
 
 def generate_gear_sensor_id(athlete_id: str, gear_id: str, sensor_type: str) -> str:

--- a/tests/custom_components/ha_strava/test_activity_attribute_sensors.py
+++ b/tests/custom_components/ha_strava/test_activity_attribute_sensors.py
@@ -73,7 +73,7 @@ class TestStravaActivityAttributeSensor:
 
         device_info = sensor.device_info
         assert device_info["identifiers"] == {("ha_strava", "strava_12345_run")}
-        assert device_info["name"] == "Strava Test User Run"
+        assert device_info["name"] == "Run"
         assert device_info["manufacturer"] == "Powered by Strava"
         assert device_info["model"] == "Run Activity"
 

--- a/tests/custom_components/ha_strava/test_activity_type_sensors.py
+++ b/tests/custom_components/ha_strava/test_activity_type_sensors.py
@@ -348,7 +348,7 @@ class TestStravaActivityTypeSensor:
 
         # Verify device info
         assert device_info["identifiers"] == {("ha_strava", "strava_12345_run")}
-        assert device_info["name"] == "Strava Test User Run"
+        assert device_info["name"] == "Run"
         assert device_info["manufacturer"] == "Powered by Strava"
         assert device_info["model"] == "Run Activity"
 

--- a/tests/custom_components/ha_strava/test_constants_multiple_activities.py
+++ b/tests/custom_components/ha_strava/test_constants_multiple_activities.py
@@ -86,56 +86,61 @@ class TestGenerateRecentActivityDeviceId:
 
 
 class TestGenerateRecentActivityDeviceName:
-    """Test generate_recent_activity_device_name function."""
+    """Test generate_recent_activity_device_name function.
+
+    The athlete_name argument is accepted for signature compatibility but
+    no longer appears in the returned string — athlete identity is shown
+    via the config entry, and the device name is kept short.
+    """
 
     def test_default_index_zero(self):
         """Test device name generation with default index (0)."""
         athlete_name = "John Doe"
         device_name = generate_recent_activity_device_name(athlete_name)
-        assert device_name == "Strava John Doe Recent Activity"
+        assert device_name == "Recent Activity"
 
     def test_explicit_index_zero(self):
         """Test device name generation with explicit index 0."""
         athlete_name = "John Doe"
         device_name = generate_recent_activity_device_name(athlete_name, 0)
-        assert device_name == "Strava John Doe Recent Activity"
+        assert device_name == "Recent Activity"
 
     def test_index_one(self):
         """Test device name generation with index 1."""
         athlete_name = "John Doe"
         device_name = generate_recent_activity_device_name(athlete_name, 1)
-        assert device_name == "Strava John Doe Recent Activity 2"
+        assert device_name == "Recent Activity 2"
 
     def test_index_two(self):
         """Test device name generation with index 2."""
         athlete_name = "John Doe"
         device_name = generate_recent_activity_device_name(athlete_name, 2)
-        assert device_name == "Strava John Doe Recent Activity 3"
+        assert device_name == "Recent Activity 3"
 
     def test_index_nine(self):
         """Test device name generation with index 9 (max)."""
         athlete_name = "John Doe"
         device_name = generate_recent_activity_device_name(athlete_name, 9)
-        assert device_name == "Strava John Doe Recent Activity 10"
+        assert device_name == "Recent Activity 10"
 
     def test_different_athlete_names(self):
-        """Test device name generation with different athlete names."""
+        """Test device name generation is independent of athlete name."""
         # Test with single name
         device_name = generate_recent_activity_device_name("Alice", 1)
-        assert device_name == "Strava Alice Recent Activity 2"
+        assert device_name == "Recent Activity 2"
 
         # Test with multiple names
         device_name = generate_recent_activity_device_name("Bob Smith", 2)
-        assert device_name == "Strava Bob Smith Recent Activity 3"
+        assert device_name == "Recent Activity 3"
 
         # Test with special characters
         device_name = generate_recent_activity_device_name("José María", 1)
-        assert device_name == "Strava José María Recent Activity 2"
+        assert device_name == "Recent Activity 2"
 
     def test_empty_athlete_name(self):
         """Test device name generation with empty athlete name."""
         device_name = generate_recent_activity_device_name("", 1)
-        assert device_name == "Strava  Recent Activity 2"
+        assert device_name == "Recent Activity 2"
 
     def test_index_numbering_starts_at_two(self):
         """Test that index numbering starts at 2 (index 1 -> 2, index 2 -> 3, etc.)."""
@@ -144,12 +149,10 @@ class TestGenerateRecentActivityDeviceName:
         for i in range(10):
             device_name = generate_recent_activity_device_name(athlete_name, i)
             if i == 0:
-                assert device_name == "Strava Test User Recent Activity"
+                assert device_name == "Recent Activity"
             else:
                 expected_number = i + 1
-                assert (
-                    device_name == f"Strava Test User Recent Activity {expected_number}"
-                )
+                assert device_name == f"Recent Activity {expected_number}"
 
 
 class TestGenerateRecentActivitySensorId:
@@ -268,7 +271,7 @@ class TestEdgeCases:
 
         # Device name with negative index
         device_name = generate_recent_activity_device_name(athlete_name, -1)
-        assert device_name == "Strava Test User Recent Activity 0"
+        assert device_name == "Recent Activity 0"
 
     def test_large_index(self):
         """Test behavior with large index."""
@@ -281,7 +284,7 @@ class TestEdgeCases:
 
         # Device name with large index
         device_name = generate_recent_activity_device_name(athlete_name, 100)
-        assert device_name == "Strava Test User Recent Activity 101"
+        assert device_name == "Recent Activity 101"
 
     def test_empty_strings(self):
         """Test behavior with empty strings."""
@@ -291,7 +294,7 @@ class TestEdgeCases:
 
         # Empty athlete name
         device_name = generate_recent_activity_device_name("", 1)
-        assert device_name == "Strava  Recent Activity 2"
+        assert device_name == "Recent Activity 2"
 
         # Empty sensor type
         sensor_id = generate_recent_activity_sensor_id("12345", "", 1)
@@ -308,7 +311,7 @@ class TestEdgeCases:
 
         # Test with None athlete_name
         device_name = generate_recent_activity_device_name(None, 1)
-        assert device_name == "Strava None Recent Activity 2"
+        assert device_name == "Recent Activity 2"
 
         # Test with None sensor_type
         sensor_id = generate_recent_activity_sensor_id("12345", None, 1)

--- a/tests/custom_components/ha_strava/test_multi_athlete_naming.py
+++ b/tests/custom_components/ha_strava/test_multi_athlete_naming.py
@@ -1,12 +1,14 @@
 """Test that entity naming/grouping stays isolated per athlete.
 
-Sensor `name` properties were shortened to drop the "Strava {athlete}"
-prefix, relying on `has_entity_name` so Home Assistant composes the
-displayed name from the device name. This module verifies that removing
-the prefix from entity names does not collapse grouping or identity
-across multiple athlete config entries: unique_id and device identifiers
-must still be athlete-scoped even though the entity `name` text is now
-identical for equivalent sensors across athletes.
+Sensor `name` properties and device names were shortened to drop the
+"Strava {athlete}" prefix, relying on `has_entity_name` so Home Assistant
+composes the displayed name from the device name, and on each athlete
+having their own config entry for visual separation in the UI. This
+module verifies that removing the prefix does not collapse grouping or
+identity across multiple athlete config entries: unique_id and device
+identifiers must still be athlete-scoped even though the entity `name`
+and device `name` text are now identical for equivalent sensors across
+athletes.
 """
 
 from unittest.mock import MagicMock
@@ -64,11 +66,10 @@ class TestActivityTypeSensorIsolation:
         assert (DOMAIN, "strava_11111_run") in sensor_a.device_info["identifiers"]
         assert (DOMAIN, "strava_22222_run") in sensor_b.device_info["identifiers"]
 
-        # Device names still carry the athlete name, so the UI stays
-        # distinguishable even though entity names are athlete-agnostic.
-        assert sensor_a.device_info["name"] != sensor_b.device_info["name"]
-        assert "Alice Athlete" in sensor_a.device_info["name"]
-        assert "Bob Athlete" in sensor_b.device_info["name"]
+        # Device names are also athlete-agnostic now ("Run" for both) — the
+        # config entry (one per athlete) is what visually separates them in
+        # the HA UI, and identifiers/unique_id are what enforce isolation.
+        assert sensor_a.device_info["name"] == sensor_b.device_info["name"] == "Run"
 
 
 class TestActivityAttributeSensorIsolation:

--- a/tests/custom_components/ha_strava/test_multiple_recent_activities.py
+++ b/tests/custom_components/ha_strava/test_multiple_recent_activities.py
@@ -55,14 +55,14 @@ class TestNamingConventions:
 
         # Test index 0 (backward compatibility)
         device_name_0 = generate_recent_activity_device_name(athlete_name, 0)
-        assert device_name_0 == "Strava John Doe Recent Activity"
+        assert device_name_0 == "Recent Activity"
 
         # Test index 1+ (numbered)
         device_name_1 = generate_recent_activity_device_name(athlete_name, 1)
-        assert device_name_1 == "Strava John Doe Recent Activity 2"
+        assert device_name_1 == "Recent Activity 2"
 
         device_name_2 = generate_recent_activity_device_name(athlete_name, 2)
-        assert device_name_2 == "Strava John Doe Recent Activity 3"
+        assert device_name_2 == "Recent Activity 3"
 
     def test_generate_recent_activity_sensor_id(self):
         """Test sensor ID generation for different activity indices."""
@@ -189,13 +189,13 @@ class TestStravaRecentActivitySensor:
         sensor_0 = StravaRecentActivitySensor(coordinator, "12345", 0)
         device_info_0 = sensor_0.device_info
         assert device_info_0["identifiers"] == {("ha_strava", "strava_12345_recent")}
-        assert device_info_0["name"] == "Strava Test User Recent Activity"
+        assert device_info_0["name"] == "Recent Activity"
 
         # Test index 1
         sensor_1 = StravaRecentActivitySensor(coordinator, "12345", 1)
         device_info_1 = sensor_1.device_info
         assert device_info_1["identifiers"] == {("ha_strava", "strava_12345_recent_2")}
-        assert device_info_1["name"] == "Strava Test User Recent Activity 2"
+        assert device_info_1["name"] == "Recent Activity 2"
 
 
 class TestStravaRecentActivityAttributeSensor:
@@ -234,7 +234,7 @@ class TestStravaRecentActivityAttributeSensor:
 
         device_info = sensor.device_info
         assert device_info["identifiers"] == {("ha_strava", "strava_12345_recent_3")}
-        assert device_info["name"] == "Strava Test User Recent Activity 3"
+        assert device_info["name"] == "Recent Activity 3"
 
 
 class TestSpecificRecentActivitySensors:
@@ -395,9 +395,9 @@ class TestSensorSetupWithMultipleActivities:
         device_names = [
             sensor.device_info["name"] for sensor in recent_activity_sensors
         ]
-        assert "Strava Test User Recent Activity" in device_names  # Index 0
-        assert "Strava Test User Recent Activity 2" in device_names  # Index 1
-        assert "Strava Test User Recent Activity 3" in device_names  # Index 2
+        assert "Recent Activity" in device_names  # Index 0
+        assert "Recent Activity 2" in device_names  # Index 1
+        assert "Recent Activity 3" in device_names  # Index 2
 
     @pytest.mark.asyncio
     async def test_setup_with_max_recent_activities(self, hass: HomeAssistant):


### PR DESCRIPTION
## Summary
- Root cause of the entity/dialog still showing "Strava {athlete} Recent Activity" etc.: the earlier refactor only shortened entity names, not device names, and entities with no name of their own display the device name verbatim
- Device names are now short (e.g. "Run", "Recent Activity", gear name)
- Athlete identity remains visible via the config entry (one per athlete); `device_info` identifiers and `unique_id` still carry `athlete_id`, so multi-athlete isolation is unaffected