### PR TITLE
feat: label gear name sensor by type

### DIFF
--- a/custom_components/ha_strava/const.py
+++ b/custom_components/ha_strava/const.py
@@ -601,6 +601,19 @@ def generate_gear_sensor_name(sensor_type: str) -> str:
     return sensor_type.replace("_", " ").title()
 
 
+def get_gear_type_label(gear_id: str) -> str:
+    """Return the gear type label ("Bike" or "Shoes") from a Strava gear ID.
+
+    Strava gear IDs are prefixed by type: "b" for bikes (including indoor
+    trainers) and "g" for shoes. Falls back to "Gear" for anything else.
+    """
+    if gear_id and gear_id.startswith("b"):
+        return "Bike"
+    if gear_id and gear_id.startswith("g"):
+        return "Shoes"
+    return "Gear"
+
+
 def normalize_activity_type(activity_type: str) -> str:
     """Normalize activity type for consistent naming."""
     if activity_type is None or not isinstance(activity_type, str):

--- a/custom_components/ha_strava/sensor.py
+++ b/custom_components/ha_strava/sensor.py
@@ -88,6 +88,7 @@ from .const import (
     generate_sensor_id,
     generate_sensor_name,
     get_athlete_name_from_title,
+    get_gear_type_label,
     normalize_activity_type,
 )
 from .coordinator import StravaDataUpdateCoordinator
@@ -1748,9 +1749,14 @@ class StravaRecentActivityMetricSensor(StravaRecentActivityAttributeSensor):
 
 
 class StravaGearNameSensor(CoordinatorEntity, SensorEntity):
-    """Sensor for gear name with attributes."""
+    """Sensor for gear name with attributes.
 
-    _attr_has_entity_name = True
+    has_entity_name is intentionally left off (defaults to False): the
+    device is named after the equipment itself (e.g. "ASICS GT-2000 10 US12
+    Wide"), so composing "{device name} {entity name}" would be redundant.
+    The bare entity name ("Shoes"/"Bike") is used as-is instead.
+    """
+
     _attr_state_class = None
     _attr_device_class = None
 
@@ -1804,7 +1810,11 @@ class StravaGearNameSensor(CoordinatorEntity, SensorEntity):
     @property
     def icon(self):
         """Return the icon of the sensor."""
-        return "mdi:bike"
+        return (
+            "mdi:bike"
+            if get_gear_type_label(self._gear_id) == "Bike"
+            else "mdi:shoe-sneaker"
+        )
 
     @property
     def native_value(self):
@@ -1816,12 +1826,8 @@ class StravaGearNameSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def name(self):
-        """Return the name of the sensor.
-
-        None makes this the device's primary entity: HA uses the device
-        name alone instead of concatenating an entity name onto it.
-        """
-        return None
+        """Return the name of the sensor: the gear type (e.g. "Bike", "Shoes")."""
+        return get_gear_type_label(self._gear_id)
 
     @property
     def extra_state_attributes(self):

--- a/tests/custom_components/ha_strava/test_gear_sensors.py
+++ b/tests/custom_components/ha_strava/test_gear_sensors.py
@@ -6,6 +6,7 @@ from custom_components.ha_strava.const import (
     CONF_DISTANCE_UNIT_OVERRIDE,
     CONF_DISTANCE_UNIT_OVERRIDE_METRIC,
     DOMAIN,
+    get_gear_type_label,
 )
 from custom_components.ha_strava.sensor import (
     StravaGearDistanceSensor,
@@ -109,13 +110,21 @@ class TestStravaGearNameSensor:
         assert sensor.native_value is None
 
     def test_name_property(self):
-        """name is None: this sensor is the gear device's primary entity."""
+        """name is the gear type label; has_entity_name is off so it's shown bare."""
         coordinator = _make_coordinator([GEAR_BIKE])
         sensor = StravaGearNameSensor(
             coordinator, gear_id="b111111", athlete_id="12345"
         )
-        assert sensor.name is None
-        assert sensor.has_entity_name is True
+        assert sensor.name == "Bike"
+        assert sensor.has_entity_name is False
+
+    def test_name_property_shoes(self):
+        """Shoe gear IDs (g-prefixed) get the "Shoes" type label."""
+        coordinator = _make_coordinator([GEAR_SHOES])
+        sensor = StravaGearNameSensor(
+            coordinator, gear_id="g222222", athlete_id="12345"
+        )
+        assert sensor.name == "Shoes"
 
     def test_device_info_uses_gear_id(self):
         """device_info identifiers must be based on gear ID, not index."""
@@ -215,3 +224,22 @@ class TestStravaGearDistanceSensor:
             name_sensor.device_info["identifiers"]
             == dist_sensor.device_info["identifiers"]
         )
+
+
+class TestGetGearTypeLabel:
+    """Test get_gear_type_label helper."""
+
+    def test_bike_prefix(self):
+        assert get_gear_type_label("b111111") == "Bike"
+
+    def test_shoe_prefix(self):
+        assert get_gear_type_label("g222222") == "Shoes"
+
+    def test_unknown_prefix(self):
+        assert get_gear_type_label("x999999") == "Gear"
+
+    def test_empty_string(self):
+        assert get_gear_type_label("") == "Gear"
+
+    def test_none(self):
+        assert get_gear_type_label(None) == "Gear"

--- a/tests/custom_components/ha_strava/test_multi_athlete_naming.py
+++ b/tests/custom_components/ha_strava/test_multi_athlete_naming.py
@@ -154,7 +154,7 @@ class TestGearSensorIsolation:
 
         # Same gear name/id on both athletes, but device identifiers and
         # unique_id remain athlete-scoped.
-        assert name_a.name == name_b.name is None
+        assert name_a.name == name_b.name == "Bike"
         assert name_a.unique_id != name_b.unique_id
         assert name_a.device_info["identifiers"] != name_b.device_info["identifiers"]
 


### PR DESCRIPTION
## Summary
- Gear name sensor's entity name is now the gear type ("Bike" or "Shoes", derived from Strava's b/g gear ID prefix) instead of inheriting the device name
- Equipment name (e.g. "ASICS GT-2000 10 US12 Wide") stays as the sensor's state value
- Icon now matches type (bike vs shoe) instead of always showing the bike icon
- `has_entity_name` is off for this sensor only, since the device is already named after the equipment — keeping it on would show "{equipment name} Shoes" instead of just "Shoes"