### PR TITLE
docs: note map visibility privacy setting affects route data

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ The gear items are sorted by distance (most used first), and the integration res
 
 Activity sensors expose a `polyline` attribute containing the route as a Google-encoded polyline string. Since that string isn't directly usable by map cards, the integration provides the `ha_strava.get_activity_route` service to decode it into a list of `{lat, lon}` coordinates on demand — keeping the raw encoded string in sensor attributes (recorder-friendly) while giving you real coordinates when you need to render a map.
 
+> **Note:** If you have map visibility hidden in your Strava privacy settings, Strava's API won't return route data for your activities — this applies even to your own activities. Check **Strava Settings → Privacy Controls → Map Visibility** if the `polyline` attribute is empty or the route service returns no data.
+
 **Calling the service:**
 
 ```yaml

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.4.0"
+  "version": "4.4.1"
 }

--- a/info.md
+++ b/info.md
@@ -185,6 +185,8 @@ The gear items are sorted by distance (most used first), and the integration res
 
 Activity sensors expose a `polyline` attribute containing the route as a Google-encoded polyline string. Since that string isn't directly usable by map cards, the integration provides the `ha_strava.get_activity_route` service to decode it into a list of `{lat, lon}` coordinates on demand — keeping the raw encoded string in sensor attributes (recorder-friendly) while giving you real coordinates when you need to render a map.
 
+> **Note:** If you have map visibility hidden in your Strava privacy settings, Strava's API won't return route data for your activities — this applies even to your own activities. Check **Strava Settings → Privacy Controls → Map Visibility** if the `polyline` attribute is empty or the route service returns no data.
+
 **Calling the service:**
 
 ```yaml


### PR DESCRIPTION
## Summary
- Note in README.md and info.md that hiding map visibility in Strava privacy settings prevents route/polyline data from being returned by the API, even for the athlete's own activities
- Bump manifest version to 4.4.1

Closes the follow-up raised in #196.