### PR TITLE
feat: add PR/KOM segment attributes to activity sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,14 @@ route:
 
 The [journey-viewer-card](https://github.com/nledenyi/journey-viewer-card) Lovelace card can render Strava-style per-activity maps using this service. It reads activity data from any sensor matching its [data contract](https://github.com/nledenyi/journey-viewer-card/blob/main/README.md#data-contract) and lazily loads the route via a configurable `route_service` hook, which you can point at `ha_strava.get_activity_route`. See the card's documentation for full setup instructions.
 
+## Personal Records and Segment Leaderboards
+
+Activity sensors also expose PR and KOM/QOM data pulled from the segment efforts already included in the activity detail response, so no extra API calls are needed:
+
+- `pr_count` — number of segments in the activity where a new all-time personal record was set. Available as its own metric sensor alongside `trophies`.
+- `pr_segments` — list of segment names where a new all-time personal record was set on this activity.
+- `kom_segments` — list of segment names where this activity currently holds the King/Queen of the Mountain spot (leaderboard #1).
+
 ## Contributors
 
 - [@craibo](https://github.com/craibo)

--- a/custom_components/ha_strava/const.py
+++ b/custom_components/ha_strava/const.py
@@ -86,6 +86,7 @@ CONF_SENSOR_CALORIES = "kcal"
 CONF_SENSOR_ELEVATION = "elevation_gain"
 CONF_SENSOR_POWER = "power"
 CONF_SENSOR_TROPHIES = "trophies"
+CONF_SENSOR_PR_COUNT = "pr_count"
 CONF_SENSOR_TITLE = "title"
 CONF_SENSOR_CITY = "city"
 CONF_SENSOR_MOVING_TIME = "moving_time"
@@ -210,6 +211,7 @@ CONF_SENSORS = {
     CONF_SENSOR_ELEVATION: {"icon": "mdi:elevation-rise"},
     CONF_SENSOR_POWER: {"icon": "mdi:dumbbell"},
     CONF_SENSOR_TROPHIES: {"icon": "mdi:trophy"},
+    CONF_SENSOR_PR_COUNT: {"icon": "mdi:medal"},
     CONF_SENSOR_HEART_RATE_AVG: {"icon": "mdi:heart-pulse"},
     CONF_SENSOR_HEART_RATE_MAX: {"icon": "mdi:heart-pulse"},
 }
@@ -324,6 +326,12 @@ CONF_ATTRIBUTE_SENSORS = {
         "unit": None,
         "state_class": "measurement",
     },
+    CONF_SENSOR_PR_COUNT: {
+        "icon": "mdi:medal",
+        "device_class": None,
+        "unit": None,
+        "state_class": "measurement",
+    },
     CONF_SENSOR_KUDOS: {
         "icon": "mdi:thumb-up-outline",
         "device_class": None,
@@ -398,6 +406,7 @@ CONF_ACTIVITY_TYPE_SENSOR_METRICS = [
     CONF_SENSOR_CADENCE_AVG,
     CONF_SENSOR_POWER,
     CONF_SENSOR_TROPHIES,
+    CONF_SENSOR_PR_COUNT,
     CONF_SENSOR_KUDOS,
 ]
 
@@ -417,6 +426,7 @@ CONF_ATTRIBUTE_SENSOR_TYPES = [
     CONF_SENSOR_CADENCE_AVG,
     CONF_SENSOR_POWER,
     CONF_SENSOR_TROPHIES,
+    CONF_SENSOR_PR_COUNT,
     CONF_SENSOR_KUDOS,
 ]
 
@@ -495,6 +505,8 @@ CONF_ATTR_ATHLETE_URL = "athlete_url"
 CONF_ATTR_COMMUTE = "commute"
 CONF_ATTR_PRIVATE = "private"
 CONF_ATTR_POLYLINE = "polyline"
+CONF_ATTR_PR_SEGMENTS = "pr_segments"
+CONF_ATTR_KOM_SEGMENTS = "kom_segments"
 
 # Device Source Tracking
 CONF_ATTR_DEVICE_NAME = "device_name"

--- a/custom_components/ha_strava/coordinator.py
+++ b/custom_components/ha_strava/coordinator.py
@@ -20,7 +20,9 @@ from .const import (
     CONF_API_RETRY_MAX_ATTEMPTS,
     CONF_ATTR_COMMUTE,
     CONF_ATTR_END_LATLONG,
+    CONF_ATTR_KOM_SEGMENTS,
     CONF_ATTR_POLYLINE,
+    CONF_ATTR_PR_SEGMENTS,
     CONF_ATTR_PRIVATE,
     CONF_ATTR_SPORT_TYPE,
     CONF_ATTR_START_LATLONG,
@@ -58,6 +60,7 @@ from .const import (
     CONF_SENSOR_KUDOS,
     CONF_SENSOR_MOVING_TIME,
     CONF_SENSOR_POWER,
+    CONF_SENSOR_PR_COUNT,
     CONF_SENSOR_TITLE,
     CONF_SENSOR_TROPHIES,
     CONFIG_IMG_SIZE,
@@ -753,6 +756,18 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
 
             calories_kcal = activity_dto.get("calories")
 
+        pr_segments: list[str] = []
+        kom_segments: list[str] = []
+        if activity_dto:
+            for effort in activity_dto.get("segment_efforts") or []:
+                segment_name = effort.get("name")
+                if not segment_name:
+                    continue
+                if effort.get("pr_rank") == 1:
+                    pr_segments.append(segment_name)
+                if effort.get("is_kom"):
+                    kom_segments.append(segment_name)
+
         # Fallback to basic location info
         location = (
             activity.get("location_city")
@@ -781,6 +796,7 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
             CONF_SENSOR_ELEVATION: activity.get("total_elevation_gain"),
             CONF_SENSOR_POWER: activity.get("average_watts"),
             CONF_SENSOR_TROPHIES: activity.get("achievement_count"),
+            CONF_SENSOR_PR_COUNT: activity.get("pr_count"),
             CONF_SENSOR_HEART_RATE_AVG: activity.get("average_heartrate"),
             CONF_SENSOR_HEART_RATE_MAX: activity.get("max_heartrate"),
             CONF_SENSOR_CADENCE_AVG: activity.get("average_cadence"),
@@ -790,6 +806,8 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
             CONF_ATTR_COMMUTE: activity.get("commute", False),
             CONF_ATTR_PRIVATE: activity.get("private", False),
             CONF_ATTR_POLYLINE: activity.get("map", {}).get("summary_polyline", ""),
+            CONF_ATTR_PR_SEGMENTS: pr_segments,
+            CONF_ATTR_KOM_SEGMENTS: kom_segments,
             # Activity Details
             CONF_SENSOR_CALORIES: calories_kcal,
             # Device source tracking

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.4.1"
+  "version": "4.5.0"
 }

--- a/custom_components/ha_strava/sensor.py
+++ b/custom_components/ha_strava/sensor.py
@@ -24,8 +24,10 @@ from .const import (
     CONF_ATTR_ACTIVITY_ID,
     CONF_ATTR_ACTIVITY_URL,
     CONF_ATTR_COMMUTE,
+    CONF_ATTR_KOM_SEGMENTS,
     CONF_ATTR_LOCATION,
     CONF_ATTR_POLYLINE,
+    CONF_ATTR_PR_SEGMENTS,
     CONF_ATTR_PRIVATE,
     CONF_ATTR_SPORT_TYPE,
     CONF_ATTR_START_LATLONG,
@@ -671,6 +673,8 @@ class StravaActivityTypeSensor(CoordinatorEntity, SensorEntity):
             CONF_ATTR_PRIVATE: activity.get(CONF_ATTR_PRIVATE),
             CONF_ATTR_ACTIVITY_URL: f"{STRAVA_ACTIVITY_BASE_URL}{activity_id}",
             CONF_ATTR_POLYLINE: activity.get(CONF_ATTR_POLYLINE),
+            CONF_ATTR_PR_SEGMENTS: activity.get(CONF_ATTR_PR_SEGMENTS, []),
+            CONF_ATTR_KOM_SEGMENTS: activity.get(CONF_ATTR_KOM_SEGMENTS, []),
         }
 
         # Add starting coordinates if available
@@ -1308,6 +1312,8 @@ class StravaRecentActivitySensor(CoordinatorEntity, SensorEntity):
             CONF_ATTR_PRIVATE: activity.get(CONF_ATTR_PRIVATE),
             CONF_ATTR_ACTIVITY_URL: f"{STRAVA_ACTIVITY_BASE_URL}{activity_id}",
             CONF_ATTR_POLYLINE: activity.get(CONF_ATTR_POLYLINE),
+            CONF_ATTR_PR_SEGMENTS: activity.get(CONF_ATTR_PR_SEGMENTS, []),
+            CONF_ATTR_KOM_SEGMENTS: activity.get(CONF_ATTR_KOM_SEGMENTS, []),
         }
 
         if start_latlng := activity.get(CONF_ATTR_START_LATLONG):

--- a/info.md
+++ b/info.md
@@ -209,6 +209,14 @@ route:
 
 The [journey-viewer-card](https://github.com/nledenyi/journey-viewer-card) Lovelace card can render Strava-style per-activity maps using this service. It reads activity data from any sensor matching its [data contract](https://github.com/nledenyi/journey-viewer-card/blob/main/README.md#data-contract) and lazily loads the route via a configurable `route_service` hook, which you can point at `ha_strava.get_activity_route`. See the card's documentation for full setup instructions.
 
+## Personal Records and Segment Leaderboards
+
+Activity sensors also expose PR and KOM/QOM data pulled from the segment efforts already included in the activity detail response, so no extra API calls are needed:
+
+- `pr_count` — number of segments in the activity where a new all-time personal record was set. Available as its own metric sensor alongside `trophies`.
+- `pr_segments` — list of segment names where a new all-time personal record was set on this activity.
+- `kom_segments` — list of segment names where this activity currently holds the King/Queen of the Mountain spot (leaderboard #1).
+
 ## Contributors
 
 - [@craibo](https://github.com/craibo)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,7 @@ def mock_strava_activities():
             "average_heartrate": 150.0,
             "max_heartrate": 180.0,
             "calories": 300,
+            "pr_count": 1,
         },
         {
             "id": 2,
@@ -126,6 +127,7 @@ def mock_strava_activities():
             "average_watts": 200.0,
             "max_watts": 500.0,
             "weighted_average_watts": 180.0,
+            "pr_count": 0,
         },
         {
             "id": 3,
@@ -147,6 +149,7 @@ def mock_strava_activities():
             "average_speed": 1.67,
             "max_speed": 2.5,
             "calories": 100,
+            "pr_count": 0,
         },
         {
             "id": 4,
@@ -168,6 +171,7 @@ def mock_strava_activities():
             "average_speed": 0.83,
             "max_speed": 1.2,
             "calories": 200,
+            "pr_count": 0,
             "laps": [
                 {"lap_index": 1, "split": 120, "distance": 50.0},
                 {"lap_index": 2, "split": 125, "distance": 50.0},

--- a/tests/custom_components/ha_strava/test_coordinator.py
+++ b/tests/custom_components/ha_strava/test_coordinator.py
@@ -11,6 +11,8 @@ from custom_components.ha_strava.const import (
     CONF_ACTIVITY_TYPES_TO_TRACK,
     CONF_ATTR_DEVICE_NAME,
     CONF_ATTR_DEVICE_TYPE,
+    CONF_ATTR_KOM_SEGMENTS,
+    CONF_ATTR_PR_SEGMENTS,
     CONF_ATTR_SPORT_TYPE,
     CONF_PHOTO_CACHE_HOURS,
     CONF_PHOTO_FETCH_DELAY_SECONDS,
@@ -20,6 +22,7 @@ from custom_components.ha_strava.const import (
     CONF_SENSOR_DATE,
     CONF_SENSOR_DISTANCE,
     CONF_SENSOR_ID,
+    CONF_SENSOR_PR_COUNT,
     CONF_SENSOR_TITLE,
     DOMAIN,
 )
@@ -1481,3 +1484,54 @@ class TestStravaDataUpdateCoordinator:
         assert result is not None
         assert len(result) == 1
         assert result[0]["activity_id"] == 2
+
+    def test_sensor_activity_pr_and_kom_segments(
+        self, hass: HomeAssistant, mock_config_entry
+    ):
+        """Test that pr_count, pr_segments, and kom_segments are extracted correctly."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        activity = {
+            "id": 42,
+            "name": "Hilly Ride",
+            "type": "Ride",
+            "sport_type": "Ride",
+            "start_date_local": "2024-01-01T06:00:00Z",
+            "pr_count": 2,
+        }
+        activity_dto = {
+            "segment_efforts": [
+                {"name": "Alpe d'Huez", "is_kom": False, "pr_rank": 1},
+                {"name": "Col du Galibier", "is_kom": True, "pr_rank": None},
+                {"name": "Flat Bit", "is_kom": False, "pr_rank": None},
+                {"name": "Both At Once", "is_kom": True, "pr_rank": 1},
+            ],
+        }
+
+        result = coordinator._sensor_activity(activity, activity_dto)
+
+        assert result[CONF_SENSOR_PR_COUNT] == 2
+        assert result[CONF_ATTR_PR_SEGMENTS] == ["Alpe d'Huez", "Both At Once"]
+        assert result[CONF_ATTR_KOM_SEGMENTS] == ["Col du Galibier", "Both At Once"]
+
+    def test_sensor_activity_no_segment_efforts(
+        self, hass: HomeAssistant, mock_config_entry
+    ):
+        """Test pr_count/pr_segments/kom_segments default safely with no detail data."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        activity = {
+            "id": 43,
+            "name": "Easy Spin",
+            "type": "Ride",
+            "sport_type": "Ride",
+            "start_date_local": "2024-01-01T06:00:00Z",
+        }
+
+        result = coordinator._sensor_activity(activity, activity_dto=None)
+
+        assert result[CONF_SENSOR_PR_COUNT] is None
+        assert result[CONF_ATTR_PR_SEGMENTS] == []
+        assert result[CONF_ATTR_KOM_SEGMENTS] == []

--- a/tests/custom_components/ha_strava/test_sensor.py
+++ b/tests/custom_components/ha_strava/test_sensor.py
@@ -12,14 +12,18 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.ha_strava.const import (
     CONF_ACTIVITY_TYPES_TO_TRACK,
     CONF_ATTR_ACTIVITY_ID,
+    CONF_ATTR_KOM_SEGMENTS,
+    CONF_ATTR_PR_SEGMENTS,
     CONF_DISTANCE_UNIT_OVERRIDE,
     CONF_DISTANCE_UNIT_OVERRIDE_DEFAULT,
     CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL,
     CONF_DISTANCE_UNIT_OVERRIDE_METRIC,
+    CONF_SENSOR_PR_COUNT,
     DOMAIN,
 )
 from custom_components.ha_strava.sensor import (
     StravaActivityGearSensor,
+    StravaActivityMetricSensor,
     StravaActivityTypeSensor,
     StravaSummaryStatsSensor,
     async_setup_entry,
@@ -145,6 +149,62 @@ class TestStravaActivityTypeSensor:
         assert attributes["latitude"] == 40.7128
         assert attributes["longitude"] == -74.0060
 
+    def test_sensor_attributes_with_pr_and_kom_segments(self):
+        """Test sensor attributes include pr_segments and kom_segments."""
+        activity_with_achievements = {
+            "id": 1,
+            "name": "Test Run",
+            "type": "Run",
+            "sport_type": "Run",
+            "distance": 5000.0,
+            "moving_time": 1800,
+            "elapsed_time": 1900,
+            "total_elevation_gain": 100.0,
+            "elevation_gain": 100.0,
+            "start_date": "2024-01-01T06:00:00Z",
+            "date": "2024-01-01T06:00:00Z",
+            "commute": False,
+            "private": False,
+            "pr_segments": ["Alpe d'Huez", "Both At Once"],
+            "kom_segments": ["Col du Galibier", "Both At Once"],
+        }
+
+        coordinator = MagicMock()
+        coordinator.data = {
+            "activities": [activity_with_achievements],
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+        coordinator.entry = MagicMock()
+
+        sensor = StravaActivityTypeSensor(
+            coordinator=coordinator,
+            activity_type="Run",
+            athlete_id="12345",
+        )
+
+        attributes = sensor.extra_state_attributes
+        assert attributes[CONF_ATTR_PR_SEGMENTS] == ["Alpe d'Huez", "Both At Once"]
+        assert attributes[CONF_ATTR_KOM_SEGMENTS] == ["Col du Galibier", "Both At Once"]
+
+    def test_sensor_attributes_with_no_pr_or_kom_segments(self, mock_strava_activities):
+        """Test sensor attributes default to empty lists when no achievements present."""
+        coordinator = MagicMock()
+        coordinator.data = {
+            "activities": mock_strava_activities,
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+        coordinator.entry = MagicMock()
+
+        sensor = StravaActivityTypeSensor(
+            coordinator=coordinator,
+            activity_type="Run",
+            athlete_id="12345",
+        )
+
+        attributes = sensor.extra_state_attributes
+        assert attributes.get(CONF_ATTR_PR_SEGMENTS, []) == []
+        assert attributes.get(CONF_ATTR_KOM_SEGMENTS, []) == []
+
     @pytest.mark.asyncio
     async def test_sensor_icon_mapping(self, hass: HomeAssistant):
         """Test sensor icon mapping."""
@@ -216,6 +276,37 @@ class TestStravaActivityTypeSensor:
                 athlete_id="12345",
             )
             assert sensor.device_class == expected_device_class
+
+    def test_pr_count_metric_sensor(self):
+        """Test that pr_count flows through StravaActivityMetricSensor unchanged."""
+        activity = {
+            "id": 1,
+            "name": "Test Ride",
+            "type": "Ride",
+            "sport_type": "Ride",
+            "distance": 5000.0,
+            "moving_time": 1800,
+            "elapsed_time": 1900,
+            "total_elevation_gain": 100.0,
+            "start_date": "2024-01-01T06:00:00Z",
+            "pr_count": 3,
+        }
+
+        coordinator = MagicMock()
+        coordinator.data = {
+            "activities": [activity],
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+        coordinator.entry = MagicMock()
+
+        sensor = StravaActivityMetricSensor(
+            coordinator=coordinator,
+            activity_type="Ride",
+            metric_type=CONF_SENSOR_PR_COUNT,
+            athlete_id="12345",
+        )
+
+        assert sensor.native_value == 3
 
 
 class TestStravaSummaryStatsSensor:


### PR DESCRIPTION
## Summary
- Add `pr_count` metric sensor (mirrors existing `trophies` sensor) using data already fetched
- Add `pr_segments`/`kom_segments` list attributes on activity sensors, derived from `segment_efforts` in the activity detail response already fetched by the coordinator — no new API calls
- Document new attributes in README.md and info.md
- Bump manifest version to 4.5.0

Closes #197.