### PR TITLE
fix: request all segment efforts on activity detail

### DIFF
--- a/custom_components/ha_strava/coordinator.py
+++ b/custom_components/ha_strava/coordinator.py
@@ -238,7 +238,10 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
                 try:
                     activity_response = await self.oauth_session.async_request(
                         method="GET",
-                        url=f"https://www.strava.com/api/v3/activities/{activity_id}",
+                        url=(
+                            f"https://www.strava.com/api/v3/activities/{activity_id}"
+                            "?include_all_efforts=true"
+                        ),
                     )
                     if activity_response.status == 200:
                         response_json = await activity_response.json()
@@ -660,7 +663,10 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             response = await self.oauth_session.async_request(
                 method="GET",
-                url=f"https://www.strava.com/api/v3/activities/{activity_id}",
+                url=(
+                    f"https://www.strava.com/api/v3/activities/{activity_id}"
+                    "?include_all_efforts=true"
+                ),
             )
             response.raise_for_status()
             activity_detail = await response.json()

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.5.0"
+  "version": "4.5.1"
 }

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.5.1"
+  "version": "4.5.0"
 }

--- a/tests/custom_components/ha_strava/test_coordinator.py
+++ b/tests/custom_components/ha_strava/test_coordinator.py
@@ -100,6 +100,64 @@ class TestStravaDataUpdateCoordinator:
         assert activities[0][CONF_SENSOR_TITLE] == "Morning Run"
 
     @pytest.mark.asyncio
+    async def test_fetch_activities_requests_all_segment_efforts(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry,
+        mock_strava_activities,
+        aioresponses_mock,
+    ):
+        """Detail fetches must request include_all_efforts=true.
+
+        Without it, Strava's API only returns a subset of segment efforts
+        (the ones it deems noteworthy), which can under-report PRs/KOMs
+        even for non-private activities.
+        """
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        aioresponses_mock.get(
+            "https://www.strava.com/api/v3/athlete/activities?per_page=200",
+            payload=mock_strava_activities,
+            status=200,
+        )
+
+        activity_types_seen = set()
+        activities_needing_details = set()
+        filtered_activity_count = 0
+        for activity in mock_strava_activities:
+            activity_type = activity.get("type")
+            activity_id = activity["id"]
+            filtered_activity_count += 1
+            if activity_type not in activity_types_seen:
+                activity_types_seen.add(activity_type)
+                activities_needing_details.add(activity_id)
+            if filtered_activity_count <= 1:
+                activities_needing_details.add(activity_id)
+
+        for activity_id in activities_needing_details:
+            aioresponses_mock.get(
+                f"https://www.strava.com/api/v3/activities/{activity_id}"
+                "?include_all_efforts=true",
+                payload={},
+                status=200,
+            )
+
+        await coordinator._fetch_activities()
+
+        requested_urls = [str(key[1]) for key in aioresponses_mock.requests]
+        for activity_id in activities_needing_details:
+            matching = [
+                url
+                for url in requested_urls
+                if url.startswith(
+                    f"https://www.strava.com/api/v3/activities/{activity_id}"
+                )
+            ]
+            assert matching, f"No detail request found for activity {activity_id}"
+            assert all("include_all_efforts=true" in url for url in matching)
+
+    @pytest.mark.asyncio
     async def test_fetch_activities_filtered_by_type(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## Summary
- Add `include_all_efforts=true` to the activity detail endpoint requests — without it, Strava only returns a subset of segment efforts it deems noteworthy, which could under-report achievements/PRs/KOMs even for non-private activities
- Applies to both the coordinator's regular detail fetch and the webhook-triggered single-activity refresh

Investigated after a user report of achievements showing 0 despite Strava's UI showing real achievements. Confirmed with production log evidence that the affected activity had an empty `segment_efforts` array from the API even after switching its visibility to Followers, ruling out privacy as the cause and pointing at the missing `include_all_efforts` parameter.