### PR TITLE
Add Weekly Stats Sensors for Monday-Sunday Activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ When configuring the Strava API, the **Authorization Callback Domain** must be s
 
 - Gives you access to **your most recent activities** in Strava.
 - Pulls Recent (last 4 weeks), Year-to-Date (YTD) and All-Time **summary statistics**
+- Pulls current Monday-to-Sunday **weekly summary statistics** from Strava's activities endpoint
 - Creates a **camera entity** in Home Assistant to **feature recent Strava pictures** as a photo-carousel
 - Supports both the **metric and the imperial** unit system
 - Activity data in Home Assistant **auto-updates** whenever you add, modify, or delete activities on Strava
@@ -56,6 +57,7 @@ The Strava Home Assistant Integration creates **sensor entities** for each activ
 **Summary Statistics Sensors:**
 
 - **Recent** (last 4 weeks): Distance, activity count, and other metrics
+- **Weekly** (current Monday-to-Sunday week): Distance, activity count, moving time, and elevation gain where applicable
 - **Year-to-Date**: Cumulative statistics for the current year
 - **All-Time**: Lifetime statistics for each activity type
 

--- a/custom_components/ha_strava/const.py
+++ b/custom_components/ha_strava/const.py
@@ -49,6 +49,7 @@ CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL = "imperial"
 # Activity Type Selection
 CONF_ACTIVITY_TYPES_TO_TRACK = "activity_types_to_track"
 DEFAULT_ACTIVITY_TYPES = ["Run", "Ride", "Swim"]
+SUMMARY_ACTIVITY_TYPES = ["Run", "Ride", "Swim"]
 
 # Recent Activity Configuration
 CONF_NUM_RECENT_ACTIVITIES = "num_recent_activities"
@@ -62,6 +63,8 @@ CONF_NUM_GEAR_SENSORS_DEFAULT = 3
 
 STRAVA_ACTIVITY_BASE_URL = "https://www.strava.com/activities/"
 STRAVA_ACTHLETE_BASE_URL = "https://www.strava.com/dashboard"
+STRAVA_ACTIVITIES_URL = "https://www.strava.com/api/v3/athlete/activities"
+STRAVA_ACTIVITIES_PER_PAGE = 200
 
 # Event Specs
 CONF_STRAVA_DATA_UPDATE_EVENT = "strava_data_update"

--- a/custom_components/ha_strava/const.py
+++ b/custom_components/ha_strava/const.py
@@ -63,8 +63,6 @@ CONF_NUM_GEAR_SENSORS_DEFAULT = 3
 
 STRAVA_ACTIVITY_BASE_URL = "https://www.strava.com/activities/"
 STRAVA_ACTHLETE_BASE_URL = "https://www.strava.com/dashboard"
-STRAVA_ACTIVITIES_URL = "https://www.strava.com/api/v3/athlete/activities"
-STRAVA_ACTIVITIES_PER_PAGE = 200
 
 # Event Specs
 CONF_STRAVA_DATA_UPDATE_EVENT = "strava_data_update"

--- a/custom_components/ha_strava/const.py
+++ b/custom_components/ha_strava/const.py
@@ -49,7 +49,6 @@ CONF_DISTANCE_UNIT_OVERRIDE_IMPERIAL = "imperial"
 # Activity Type Selection
 CONF_ACTIVITY_TYPES_TO_TRACK = "activity_types_to_track"
 DEFAULT_ACTIVITY_TYPES = ["Run", "Ride", "Swim"]
-SUMMARY_ACTIVITY_TYPES = ["Run", "Ride", "Swim"]
 
 # Recent Activity Configuration
 CONF_NUM_RECENT_ACTIVITIES = "num_recent_activities"

--- a/custom_components/ha_strava/const.py
+++ b/custom_components/ha_strava/const.py
@@ -32,6 +32,27 @@ CONF_PHOTO_CACHE_HOURS = 24
 CONF_API_RETRY_MAX_ATTEMPTS = 3
 CONF_API_RETRY_BASE_DELAY_SECONDS = 1
 
+# Weekly Summary Sensors
+WEEKLY_SUMMARY_ACTIVITY_TYPES = ("Run", "Ride", "Swim")
+WEEKLY_ACTIVITIES_PER_PAGE = 200
+WEEKLY_ACTIVITIES_MAX_PAGES = 10
+# Maps Strava sport_type variants to the general category their weekly
+# totals roll up into, mirroring how Strava's own stats endpoint groups
+# ride/run variants under recent_ride_totals/recent_run_totals.
+WEEKLY_SPORT_TYPE_TO_CATEGORY = {
+    "Ride": "Ride",
+    "MountainBikeRide": "Ride",
+    "GravelRide": "Ride",
+    "EBikeRide": "Ride",
+    "EMountainBikeRide": "Ride",
+    "VirtualRide": "Ride",
+    "Velomobile": "Ride",
+    "Run": "Run",
+    "TrailRun": "Run",
+    "VirtualRun": "Run",
+    "Swim": "Swim",
+}
+
 # Webhook & API Specs
 CONF_WEBHOOK_ID = "webhook_id"
 CONF_CALLBACK_URL = "callback_url"

--- a/custom_components/ha_strava/coordinator.py
+++ b/custom_components/ha_strava/coordinator.py
@@ -68,8 +68,6 @@ from .const import (
     DOMAIN,
     OAUTH2_AUTHORIZE,
     OAUTH2_TOKEN,
-    STRAVA_ACTIVITIES_PER_PAGE,
-    STRAVA_ACTIVITIES_URL,
     SUMMARY_ACTIVITY_TYPES,
     SUPPORTED_ACTIVITY_TYPES,
     normalize_activity_type,
@@ -146,7 +144,7 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             response = await self.oauth_session.async_request(
                 method="GET",
-                url=f"{STRAVA_ACTIVITIES_URL}?per_page={STRAVA_ACTIVITIES_PER_PAGE}",
+                url="https://www.strava.com/api/v3/athlete/activities?per_page=200",
             )
             response.raise_for_status()
             activities_json = await response.json()
@@ -288,6 +286,7 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
     async def _fetch_weekly_totals(self) -> dict:
         """Fetch and aggregate activities in the current Monday-to-Sunday week."""
         after, before = self._weekly_activity_window()
+        per_page = 200
         weekly_totals = {
             f"weekly_{normalize_activity_type(activity_type)}_totals": {
                 "count": 0,
@@ -303,8 +302,9 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
         page = 1
         while True:
             url = (
-                f"{STRAVA_ACTIVITIES_URL}?after={after}&before={before}"
-                f"&page={page}&per_page={STRAVA_ACTIVITIES_PER_PAGE}"
+                "https://www.strava.com/api/v3/athlete/activities?"
+                f"after={after}&before={before}"
+                f"&page={page}&per_page={per_page}"
             )
             _LOGGER.debug("Fetching weekly activities page %s", page)
             try:
@@ -340,7 +340,7 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
                 totals["elevation_gain"] += activity.get("total_elevation_gain") or 0
                 totals["achievement_count"] += activity.get("achievement_count") or 0
 
-            if len(activities_json) < STRAVA_ACTIVITIES_PER_PAGE:
+            if len(activities_json) < per_page:
                 break
             page += 1
 

--- a/custom_components/ha_strava/coordinator.py
+++ b/custom_components/ha_strava/coordinator.py
@@ -69,6 +69,10 @@ from .const import (
     OAUTH2_AUTHORIZE,
     OAUTH2_TOKEN,
     SUPPORTED_ACTIVITY_TYPES,
+    WEEKLY_ACTIVITIES_MAX_PAGES,
+    WEEKLY_ACTIVITIES_PER_PAGE,
+    WEEKLY_SPORT_TYPE_TO_CATEGORY,
+    WEEKLY_SUMMARY_ACTIVITY_TYPES,
     normalize_activity_type,
 )
 
@@ -285,26 +289,41 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
     async def _fetch_weekly_totals(self) -> dict:
         """Fetch and aggregate activities in the current Monday-to-Sunday week."""
         after, before = self._weekly_activity_window()
-        per_page = 200
-        summary_activity_types = ("Run", "Ride", "Swim")
+
+        # Only aggregate types the user has selected to track, matching
+        # _fetch_activities' filtering behavior.
+        selected_activity_types = (
+            self.entry.options.get(CONF_ACTIVITY_TYPES_TO_TRACK)
+            if CONF_ACTIVITY_TYPES_TO_TRACK in self.entry.options
+            else (
+                self.entry.data.get(CONF_ACTIVITY_TYPES_TO_TRACK)
+                if CONF_ACTIVITY_TYPES_TO_TRACK in self.entry.data
+                else []
+            )
+        )
+        summary_activity_types = tuple(
+            activity_type
+            for activity_type in WEEKLY_SUMMARY_ACTIVITY_TYPES
+            if activity_type in selected_activity_types
+        )
         weekly_totals = {
             f"weekly_{normalize_activity_type(activity_type)}_totals": {
                 "count": 0,
                 "distance": 0.0,
                 "moving_time": 0,
-                "elapsed_time": 0,
                 "elevation_gain": 0.0,
-                "achievement_count": 0,
             }
             for activity_type in summary_activity_types
         }
+        if not summary_activity_types:
+            return weekly_totals
 
         page = 1
         while True:
             url = (
                 "https://www.strava.com/api/v3/athlete/activities?"
                 f"after={after}&before={before}"
-                f"&page={page}&per_page={per_page}"
+                f"&page={page}&per_page={WEEKLY_ACTIVITIES_PER_PAGE}"
             )
             _LOGGER.debug("Fetching weekly activities page %s", page)
             try:
@@ -326,23 +345,29 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
                 )
 
             for activity in activities_json:
-                activity_type = activity.get("type")
-                if activity_type not in summary_activity_types:
+                raw_activity_type = activity.get("sport_type") or activity.get("type")
+                activity_category = WEEKLY_SPORT_TYPE_TO_CATEGORY.get(raw_activity_type)
+                if activity_category not in summary_activity_types:
                     continue
 
                 totals = weekly_totals[
-                    f"weekly_{normalize_activity_type(activity_type)}_totals"
+                    f"weekly_{normalize_activity_type(activity_category)}_totals"
                 ]
                 totals["count"] += 1
                 totals["distance"] += activity.get("distance") or 0
                 totals["moving_time"] += activity.get("moving_time") or 0
-                totals["elapsed_time"] += activity.get("elapsed_time") or 0
                 totals["elevation_gain"] += activity.get("total_elevation_gain") or 0
-                totals["achievement_count"] += activity.get("achievement_count") or 0
 
-            if len(activities_json) < per_page:
+            if len(activities_json) < WEEKLY_ACTIVITIES_PER_PAGE:
                 break
             page += 1
+            if page > WEEKLY_ACTIVITIES_MAX_PAGES:
+                _LOGGER.warning(
+                    "Reached max page limit (%s) fetching weekly activities; "
+                    "totals may be incomplete",
+                    WEEKLY_ACTIVITIES_MAX_PAGES,
+                )
+                break
 
         return weekly_totals
 

--- a/custom_components/ha_strava/coordinator.py
+++ b/custom_components/ha_strava/coordinator.py
@@ -6,6 +6,7 @@ import logging
 from datetime import datetime as dt
 from datetime import timedelta
 from typing import Tuple
+from zoneinfo import ZoneInfo
 
 import aiohttp
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
@@ -67,7 +68,11 @@ from .const import (
     DOMAIN,
     OAUTH2_AUTHORIZE,
     OAUTH2_TOKEN,
+    STRAVA_ACTIVITIES_PER_PAGE,
+    STRAVA_ACTIVITIES_URL,
+    SUMMARY_ACTIVITY_TYPES,
     SUPPORTED_ACTIVITY_TYPES,
+    normalize_activity_type,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -122,6 +127,7 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
             athlete_id, activities = await self._fetch_activities()
             raw_summary_stats = await self._fetch_summary_stats(athlete_id)
             summary_stats = self._sensor_summary_stats(raw_summary_stats)
+            summary_stats.update(await self._fetch_weekly_totals())
             images = await self._fetch_images(activities)
             gear = await self._fetch_gear(athlete_id)
 
@@ -140,7 +146,7 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             response = await self.oauth_session.async_request(
                 method="GET",
-                url="https://www.strava.com/api/v3/athlete/activities?per_page=200",
+                url=f"{STRAVA_ACTIVITIES_URL}?per_page={STRAVA_ACTIVITIES_PER_PAGE}",
             )
             response.raise_for_status()
             activities_json = await response.json()
@@ -269,6 +275,76 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
             key=lambda activity: activity[CONF_SENSOR_DATE],
             reverse=True,
         )
+
+    def _weekly_activity_window(self) -> tuple[int, int]:
+        """Return the current Monday-to-Monday window as Strava timestamps."""
+        now = dt.now(ZoneInfo(self.hass.config.time_zone))
+        week_start = (now - timedelta(days=now.weekday())).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        week_end = week_start + timedelta(days=7)
+        return int(week_start.timestamp()), int(week_end.timestamp())
+
+    async def _fetch_weekly_totals(self) -> dict:
+        """Fetch and aggregate activities in the current Monday-to-Sunday week."""
+        after, before = self._weekly_activity_window()
+        weekly_totals = {
+            f"weekly_{normalize_activity_type(activity_type)}_totals": {
+                "count": 0,
+                "distance": 0.0,
+                "moving_time": 0,
+                "elapsed_time": 0,
+                "elevation_gain": 0.0,
+                "achievement_count": 0,
+            }
+            for activity_type in SUMMARY_ACTIVITY_TYPES
+        }
+
+        page = 1
+        while True:
+            url = (
+                f"{STRAVA_ACTIVITIES_URL}?after={after}&before={before}"
+                f"&page={page}&per_page={STRAVA_ACTIVITIES_PER_PAGE}"
+            )
+            _LOGGER.debug("Fetching weekly activities page %s", page)
+            try:
+                response = await self.oauth_session.async_request(method="GET", url=url)
+                response.raise_for_status()
+                activities_json = await response.json()
+            except aiohttp.ClientError as err:
+                _LOGGER.error(f"Error fetching weekly activities: {err}")
+                raise UpdateFailed(f"Error fetching weekly activities: {err}") from err
+            except json.JSONDecodeError as json_err:
+                _LOGGER.error(f"Invalid weekly activities response: {json_err}")
+                raise UpdateFailed(
+                    f"Invalid weekly activities response: {json_err}"
+                ) from json_err
+
+            if not isinstance(activities_json, list):
+                raise UpdateFailed(
+                    "Invalid weekly activities response: expected a list"
+                )
+
+            for activity in activities_json:
+                activity_type = activity.get("type")
+                if activity_type not in SUMMARY_ACTIVITY_TYPES:
+                    continue
+
+                totals = weekly_totals[
+                    f"weekly_{normalize_activity_type(activity_type)}_totals"
+                ]
+                totals["count"] += 1
+                totals["distance"] += activity.get("distance") or 0
+                totals["moving_time"] += activity.get("moving_time") or 0
+                totals["elapsed_time"] += activity.get("elapsed_time") or 0
+                totals["elevation_gain"] += activity.get("total_elevation_gain") or 0
+                totals["achievement_count"] += activity.get("achievement_count") or 0
+
+            if len(activities_json) < STRAVA_ACTIVITIES_PER_PAGE:
+                break
+            page += 1
+
+        return weekly_totals
 
     async def _fetch_summary_stats(self, athlete_id: str) -> dict:
         _LOGGER.debug("Fetching summary stats")

--- a/custom_components/ha_strava/coordinator.py
+++ b/custom_components/ha_strava/coordinator.py
@@ -68,7 +68,6 @@ from .const import (
     DOMAIN,
     OAUTH2_AUTHORIZE,
     OAUTH2_TOKEN,
-    SUMMARY_ACTIVITY_TYPES,
     SUPPORTED_ACTIVITY_TYPES,
     normalize_activity_type,
 )
@@ -287,6 +286,7 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
         """Fetch and aggregate activities in the current Monday-to-Sunday week."""
         after, before = self._weekly_activity_window()
         per_page = 200
+        summary_activity_types = ("Run", "Ride", "Swim")
         weekly_totals = {
             f"weekly_{normalize_activity_type(activity_type)}_totals": {
                 "count": 0,
@@ -296,7 +296,7 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
                 "elevation_gain": 0.0,
                 "achievement_count": 0,
             }
-            for activity_type in SUMMARY_ACTIVITY_TYPES
+            for activity_type in summary_activity_types
         }
 
         page = 1
@@ -327,7 +327,7 @@ class StravaDataUpdateCoordinator(DataUpdateCoordinator):
 
             for activity in activities_json:
                 activity_type = activity.get("type")
-                if activity_type not in SUMMARY_ACTIVITY_TYPES:
+                if activity_type not in summary_activity_types:
                     continue
 
                 totals = weekly_totals[

--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.5.0"
+  "version": "4.6.0"
 }

--- a/custom_components/ha_strava/sensor.py
+++ b/custom_components/ha_strava/sensor.py
@@ -235,7 +235,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     # Activity types and their periods
     activity_types = ["run", "ride", "swim"]
-    periods = ["recent", "all", "ytd"]
+    periods = ["recent", "all", "ytd", "weekly"]
 
     # Metrics to create sensors for
     metrics = ["distance", "count", "moving_time"]
@@ -369,12 +369,15 @@ class StravaSummaryStatsSensor(CoordinatorEntity, SensorEntity):
             "recent_run_totals": "mdi:run",
             "all_run_totals": "mdi:run",
             "ytd_run_totals": "mdi:run",
+            "weekly_run_totals": "mdi:run",
             "recent_ride_totals": "mdi:bike",
             "all_ride_totals": "mdi:bike",
             "ytd_ride_totals": "mdi:bike",
+            "weekly_ride_totals": "mdi:bike",
             "recent_swim_totals": "mdi:swim",
             "all_swim_totals": "mdi:swim",
             "ytd_swim_totals": "mdi:swim",
+            "weekly_swim_totals": "mdi:swim",
             "biggest_ride_distance": "mdi:map-marker-distance",
             "biggest_climb_elevation_gain": "mdi:elevation-rise",
         }

--- a/info.md
+++ b/info.md
@@ -24,6 +24,7 @@ When configuring the Strava API, the **Authorization Callback Domain** must be s
 
 - Gives you access to **your most recent activities** in Strava.
 - Pulls Recent (last 4 weeks), Year-to-Date (YTD) and All-Time **summary statistics**
+- Pulls current Monday-to-Sunday **weekly summary statistics** from Strava's activities endpoint
 - Creates a **camera entity** in Home Assistant to **feature recent Strava pictures** as a photo-carousel
 - Supports both the **metric and the imperial** unit system
 - Activity data in Home Assistant **auto-updates** whenever you add, modify, or delete activities on Strava
@@ -46,6 +47,7 @@ The Strava Home Assistant Integration creates **sensor entities** for each activ
 **Summary Statistics Sensors:**
 
 - **Recent** (last 4 weeks): Distance, activity count, and other metrics
+- **Weekly** (current Monday-to-Sunday week): Distance, activity count, moving time, and elevation gain where applicable
 - **Year-to-Date**: Cumulative statistics for the current year
 - **All-Time**: Lifetime statistics for each activity type
 

--- a/tests/custom_components/ha_strava/test_coordinator.py
+++ b/tests/custom_components/ha_strava/test_coordinator.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -691,28 +692,41 @@ class TestStravaDataUpdateCoordinator:
             "count": 2,
             "distance": pytest.approx(12769.9),
             "moving_time": 7300,
-            "elapsed_time": 7500,
             "elevation_gain": pytest.approx(150.0),
-            "achievement_count": 1,
         }
         assert weekly_totals["weekly_ride_totals"] == {
             "count": 1,
             "distance": pytest.approx(25000.0),
             "moving_time": 3600,
-            "elapsed_time": 3700,
             "elevation_gain": pytest.approx(500.0),
-            "achievement_count": 2,
         }
         assert "weekly_walk_totals" not in weekly_totals
         assert "weekly_hike_totals" not in weekly_totals
 
     @pytest.mark.asyncio
-    async def test_fetch_weekly_totals_is_independent_of_activity_selection(
-        self, hass: HomeAssistant, mock_config_entry
+    async def test_fetch_weekly_totals_respects_activity_selection(
+        self, hass: HomeAssistant
     ):
-        """Test weekly summary data is fetched independently of activity selection."""
+        """Weekly totals should only be built for selected activity types,
+        matching _fetch_activities' filtering behavior."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id="12345",
+            data={
+                CONF_CLIENT_ID: "test_client_id",
+                CONF_CLIENT_SECRET: "test_client_secret",
+                "token": {
+                    "access_token": "test_access_token",
+                    "refresh_token": "test_refresh_token",
+                    "expires_at": 4102444800,
+                    "token_type": "Bearer",
+                },
+            },
+            options={CONF_ACTIVITY_TYPES_TO_TRACK: ["Run"]},
+            title="Strava: Test User",
+        )
         with patch("homeassistant.helpers.frame.report_usage"):
-            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+            coordinator = StravaDataUpdateCoordinator(hass, entry=entry)
 
         response = MagicMock()
         response.json = AsyncMock(return_value=[])
@@ -725,9 +739,43 @@ class TestStravaDataUpdateCoordinator:
             weekly_totals = await coordinator._fetch_weekly_totals()
 
         assert "weekly_run_totals" in weekly_totals
-        assert "weekly_ride_totals" in weekly_totals
-        assert "weekly_swim_totals" in weekly_totals
+        assert "weekly_ride_totals" not in weekly_totals
+        assert "weekly_swim_totals" not in weekly_totals
         async_request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fetch_weekly_totals_no_selected_types_skips_fetch(
+        self, hass: HomeAssistant
+    ):
+        """No weekly-relevant activity types selected should skip the API call entirely."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id="12345",
+            data={
+                CONF_CLIENT_ID: "test_client_id",
+                CONF_CLIENT_SECRET: "test_client_secret",
+                "token": {
+                    "access_token": "test_access_token",
+                    "refresh_token": "test_refresh_token",
+                    "expires_at": 4102444800,
+                    "token_type": "Bearer",
+                },
+            },
+            options={CONF_ACTIVITY_TYPES_TO_TRACK: ["Walk"]},
+            title="Strava: Test User",
+        )
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=entry)
+
+        with patch.object(
+            coordinator.oauth_session,
+            "async_request",
+            new=AsyncMock(),
+        ) as async_request:
+            weekly_totals = await coordinator._fetch_weekly_totals()
+
+        assert weekly_totals == {}
+        async_request.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_coordinator_data_update(

--- a/tests/custom_components/ha_strava/test_coordinator.py
+++ b/tests/custom_components/ha_strava/test_coordinator.py
@@ -1,7 +1,7 @@
 """Test coordinator for ha_strava."""
 
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -610,6 +610,126 @@ class TestStravaDataUpdateCoordinator:
                 assert key not in stats
 
     @pytest.mark.asyncio
+    async def test_fetch_weekly_totals_uses_current_week_activity_data(
+        self, hass: HomeAssistant, mock_config_entry
+    ):
+        """Test weekly totals are aggregated from the bounded activities endpoint."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        weekly_activities = [
+            {
+                "type": "Run",
+                "sport_type": "Run",
+                "distance": 8943.3,
+                "moving_time": 5100,
+                "elapsed_time": 5200,
+                "total_elevation_gain": 100.0,
+                "achievement_count": 1,
+            },
+            {
+                "type": "Run",
+                "sport_type": "Run",
+                "distance": 3826.6,
+                "moving_time": 2200,
+                "elapsed_time": 2300,
+                "total_elevation_gain": 50.0,
+                "achievement_count": 0,
+            },
+            {
+                "type": "Ride",
+                "sport_type": "MountainBikeRide",
+                "distance": 25000.0,
+                "moving_time": 3600,
+                "elapsed_time": 3700,
+                "total_elevation_gain": 500.0,
+                "achievement_count": 2,
+            },
+            {
+                "type": "Walk",
+                "sport_type": "Walk",
+                "distance": 1000.0,
+                "moving_time": 600,
+                "elapsed_time": 650,
+                "total_elevation_gain": 10.0,
+                "achievement_count": 0,
+            },
+            {
+                "type": "Hike",
+                "sport_type": "Hike",
+                "distance": 5000.0,
+                "moving_time": 1800,
+                "elapsed_time": 1900,
+                "total_elevation_gain": 200.0,
+            },
+        ]
+        response = MagicMock()
+        response.json = AsyncMock(return_value=weekly_activities)
+
+        with (
+            patch.object(
+                coordinator,
+                "_weekly_activity_window",
+                return_value=(1786334400, 1786939200),
+            ),
+            patch.object(
+                coordinator.oauth_session,
+                "async_request",
+                new=AsyncMock(return_value=response),
+            ) as async_request,
+        ):
+            weekly_totals = await coordinator._fetch_weekly_totals()
+
+        async_request.assert_awaited_once_with(
+            method="GET",
+            url=(
+                "https://www.strava.com/api/v3/athlete/activities?"
+                "after=1786334400&before=1786939200&page=1&per_page=200"
+            ),
+        )
+        assert weekly_totals["weekly_run_totals"] == {
+            "count": 2,
+            "distance": pytest.approx(12769.9),
+            "moving_time": 7300,
+            "elapsed_time": 7500,
+            "elevation_gain": pytest.approx(150.0),
+            "achievement_count": 1,
+        }
+        assert weekly_totals["weekly_ride_totals"] == {
+            "count": 1,
+            "distance": pytest.approx(25000.0),
+            "moving_time": 3600,
+            "elapsed_time": 3700,
+            "elevation_gain": pytest.approx(500.0),
+            "achievement_count": 2,
+        }
+        assert "weekly_walk_totals" not in weekly_totals
+        assert "weekly_hike_totals" not in weekly_totals
+
+    @pytest.mark.asyncio
+    async def test_fetch_weekly_totals_is_independent_of_activity_selection(
+        self, hass: HomeAssistant, mock_config_entry
+    ):
+        """Test weekly summary data is fetched independently of activity selection."""
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coordinator = StravaDataUpdateCoordinator(hass, entry=mock_config_entry)
+
+        response = MagicMock()
+        response.json = AsyncMock(return_value=[])
+
+        with patch.object(
+            coordinator.oauth_session,
+            "async_request",
+            new=AsyncMock(return_value=response),
+        ) as async_request:
+            weekly_totals = await coordinator._fetch_weekly_totals()
+
+        assert "weekly_run_totals" in weekly_totals
+        assert "weekly_ride_totals" in weekly_totals
+        assert "weekly_swim_totals" in weekly_totals
+        async_request.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_coordinator_data_update(
         self,
         hass: HomeAssistant,
@@ -660,6 +780,13 @@ class TestStravaDataUpdateCoordinator:
             payload=mock_strava_stats,
             status=200,
         )
+        after, before = coordinator._weekly_activity_window()
+        aioresponses_mock.get(
+            f"https://www.strava.com/api/v3/athlete/activities?after={after}"
+            f"&before={before}&page=1&per_page=200",
+            payload=mock_strava_activities,
+            status=200,
+        )
 
         # Test data update
         result = await coordinator._async_update_data()
@@ -682,6 +809,7 @@ class TestStravaDataUpdateCoordinator:
             "recent_ride_totals" in result["summary_stats"]
             or "all_ride_totals" in result["summary_stats"]
         )
+        assert result["summary_stats"]["weekly_run_totals"]["count"] == 1
 
     @pytest.mark.asyncio
     async def test_coordinator_error_handling(
@@ -865,6 +993,13 @@ class TestStravaDataUpdateCoordinator:
             )
         aioresponses_mock.get(
             "https://www.strava.com/api/v3/athletes/12345/stats", status=200, payload={}
+        )
+        after, before = coordinator._weekly_activity_window()
+        aioresponses_mock.get(
+            f"https://www.strava.com/api/v3/athlete/activities?after={after}"
+            f"&before={before}&page=1&per_page=200",
+            payload=malformed_activities,
+            status=200,
         )
 
         # Test data update with malformed activities

--- a/tests/custom_components/ha_strava/test_sensor.py
+++ b/tests/custom_components/ha_strava/test_sensor.py
@@ -849,11 +849,23 @@ class TestSensorPlatform:
 
             # Should create main activity sensors + individual attribute sensors + summary stats sensors
             # + recent activity sensors
-            # 4 activity types × (1 main + 15 attribute + 1 gear) + 35 summary stats + 1 recent activity device
-            # (1 main + 15 attribute + 1 gear)
-            # = 68 + 35 + 17 = 120 sensors total
-            expected_sensor_count = 120
+            # 4 activity types × (1 main + 16 attribute + 1 gear)
+            # + 35 existing summary stats + 11 weekly summary stats
+            # + 1 recent activity device (1 main + 16 attribute + 1 gear)
+            # = 72 + 35 + 11 + 18 = 136 sensors total
+            expected_sensor_count = 136
             assert len(call_args) == expected_sensor_count
+
+            weekly_sensors = [
+                sensor
+                for sensor in call_args
+                if getattr(sensor, "_api_key", "").startswith("weekly_")
+            ]
+            assert len(weekly_sensors) == 11
+            assert any(
+                sensor.name == "Weekly Run Distance" for sensor in weekly_sensors
+            )
+            assert not any("Walk" in sensor.name for sensor in weekly_sensors)
 
             # Verify that different sensor types are created
             sensor_types = [type(sensor).__name__ for sensor in call_args]
@@ -1003,8 +1015,9 @@ class TestSensorPlatform:
         call_args = async_add_entities_mock.call_args[0][0]
 
         # Should only create summary stats sensors + recent activity sensors (no activity type sensors)
-        # 35 summary stats + 1 recent activity device (1 main + 15 attribute + 1 gear) = 35 + 17 = 52 sensors
-        expected_sensor_count = 52
+        # 35 existing summary stats + 11 weekly summary stats
+        # + 1 recent activity device (1 main + 16 attribute + 1 gear) = 35 + 11 + 18 = 64 sensors
+        expected_sensor_count = 64
         assert len(call_args) == expected_sensor_count
 
         # Verify no activity type sensors are created
@@ -1232,8 +1245,9 @@ class TestStravaActivityGearSensor:
         call_args = async_add_entities_mock.call_args[0][0]
 
         # Should only create summary stats sensors + recent activity sensors (no activity type sensors)
-        # 35 summary stats + 1 recent activity device (1 main + 15 attribute + 1 gear) = 35 + 17 = 52 sensors
-        expected_sensor_count = 52
+        # 35 existing summary stats + 11 weekly summary stats
+        # + 1 recent activity device (1 main + 16 attribute + 1 gear) = 35 + 11 + 18 = 64 sensors
+        expected_sensor_count = 64
         assert len(call_args) == expected_sensor_count
 
         # Verify no activity type sensors are created
@@ -1271,10 +1285,11 @@ class TestStravaActivityGearSensor:
         async_add_entities_mock.assert_called_once()
         call_args = async_add_entities_mock.call_args[0][0]
 
-        # Should create sensors for Run and Swim (2 activity types × 17 sensors each)
-        # + 35 summary stats + 1 recent activity device (17 sensors)
-        # = 34 + 35 + 17 = 86 sensors
-        expected_sensor_count = 86
+        # Should create sensors for Run and Swim (2 activity types × 18 sensors each)
+        # + 35 existing summary stats + 11 weekly summary stats
+        # + 1 recent activity device (18 sensors)
+        # = 36 + 35 + 11 + 18 = 100 sensors
+        expected_sensor_count = 100
         assert len(call_args) == expected_sensor_count
 
         # Verify activity type sensors are created for Run and Swim


### PR DESCRIPTION
## Adds weekly summary sensors to the Home Assistant Stats device

- Adds 11 weekly Run, Ride, and Swim sensors alongside the existing YTD/recent/all summary sensors.
- Uses the current Monday-Sunday activity window that Strava commonly uses in their goals platform. The timezone uses HA's configured time zone as found here ->  in the new `ZoneInfo` import.
- This will add one additional API call per refresh as long as there are not more than 200 activities in one week.
- Tests cover weekly aggregation and sensor creation.

## Use Case

The Strava integration is great, I have been using it probably as my first integration since I started using HomeAssistant, but I keep having to do work around after work around after work around, because Strava does not natively in the API expose a simple endpoint for weekly activity summary. So using their activities endpoint and aggregating the data, we can actively track our weekly goals. This is common with many Strava users to track how many miles/kilometers in distance they have completed by the end of the week. 
