### PR TITLE
docs: note achievement fields require Everyone visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ Activity sensors also expose PR and KOM/QOM data pulled from the segment efforts
 - `pr_segments` — list of segment names where a new all-time personal record was set on this activity.
 - `kom_segments` — list of segment names where this activity currently holds the King/Queen of the Mountain spot (leaderboard #1).
 
+> **Note:** Strava appears to only populate achievement and segment-effort data (`achievements`, `pr_count`, `pr_segments`, `kom_segments`) for activities visible to Everyone. Activities set to Followers Only or Only You have consistently returned empty/zero values for these fields in testing, even though Strava's own app may still show achievements to you privately. If these attributes stay empty for an activity you expect to have achievements, check its visibility setting on Strava.
+
 > **Note:** The "Trophies" sensor was renamed to "Achievements" to match Strava's own terminology, and now correctly reads its count from the same endpoint Strava's UI uses (previously it could show 0 even when Strava displayed real achievements). Upgrading installs keep their existing entity ID (still ending in `_trophies`) so history and automations aren't broken — only the displayed name changes. Rename the entity ID manually via the UI if you'd like it to match.
 
 ## Contributors

--- a/info.md
+++ b/info.md
@@ -217,6 +217,8 @@ Activity sensors also expose PR and KOM/QOM data pulled from the segment efforts
 - `pr_segments` — list of segment names where a new all-time personal record was set on this activity.
 - `kom_segments` — list of segment names where this activity currently holds the King/Queen of the Mountain spot (leaderboard #1).
 
+> **Note:** Strava appears to only populate achievement and segment-effort data (`achievements`, `pr_count`, `pr_segments`, `kom_segments`) for activities visible to Everyone. Activities set to Followers Only or Only You have consistently returned empty/zero values for these fields in testing, even though Strava's own app may still show achievements to you privately. If these attributes stay empty for an activity you expect to have achievements, check its visibility setting on Strava.
+
 > **Note:** The "Trophies" sensor was renamed to "Achievements" to match Strava's own terminology, and now correctly reads its count from the same endpoint Strava's UI uses (previously it could show 0 even when Strava displayed real achievements). Upgrading installs keep their existing entity ID (still ending in `_trophies`) so history and automations aren't broken — only the displayed name changes. Rename the entity ID manually via the UI if you'd like it to match.
 
 ## Contributors


### PR DESCRIPTION
## Summary
- Note in README.md/info.md that `achievements`, `pr_count`, `pr_segments`, and `kom_segments` have consistently returned empty/zero for Followers Only and Only You activities in testing, even after switching visibility
- Framed as an observed pattern, not a confirmed rule — Everyone visibility hasn't been directly tested to confirm it resolves the issue