### PR TITLE
fix: report unknown for missing summary stat fields

### DIFF
--- a/custom_components/ha_strava/manifest.json
+++ b/custom_components/ha_strava/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/craibo/ha_strava/issues",
   "requirements": ["aiofiles>=23.2.1", "aiohttp>=3.9.5", "voluptuous>=0.11.7"],
-  "version": "4.6.0"
+  "version": "4.6.1"
 }

--- a/custom_components/ha_strava/sensor.py
+++ b/custom_components/ha_strava/sensor.py
@@ -412,15 +412,18 @@ class StravaSummaryStatsSensor(CoordinatorEntity, SensorEntity):
         ]:
             # Extract numeric value from data (handle both dict and numeric formats)
             if isinstance(data, dict):
-                numeric_value = data.get(self._metric_key, 0)
+                numeric_value = data.get(self._metric_key)
             else:
-                numeric_value = data if data is not None else 0
+                numeric_value = data
+
+            if numeric_value is None:
+                return None
 
             # Ensure we have a numeric value
             try:
-                numeric_value = float(numeric_value) if numeric_value is not None else 0
+                numeric_value = float(numeric_value)
             except (TypeError, ValueError):
-                numeric_value = 0
+                return None
 
             if self._metric_key == "biggest_ride_distance":
                 # Convert from meters to km/miles
@@ -450,12 +453,14 @@ class StravaSummaryStatsSensor(CoordinatorEntity, SensorEntity):
         # Handle totals data (dictionary with multiple metrics)
         if isinstance(data, dict):
             # Extract the specific metric from the totals data
-            value = data.get(self._metric_key, 0)
+            value = data.get(self._metric_key)
+            if value is None:
+                return None
 
             # Apply unit conversions for distance and elevation
             if self._metric_key == "distance":
                 # Convert from meters to km/miles
-                distance = value / 1000 if value else 0
+                distance = value / 1000
                 is_metric = self._is_metric()
                 if is_metric:
                     return round(distance, 2)
@@ -467,7 +472,7 @@ class StravaSummaryStatsSensor(CoordinatorEntity, SensorEntity):
                 )
             elif self._metric_key == "elevation_gain":
                 # Convert from meters to meters/feet
-                elevation = value if value else 0
+                elevation = value
                 is_metric = self._is_metric()
                 if is_metric:
                     return round(elevation, 2)
@@ -481,8 +486,8 @@ class StravaSummaryStatsSensor(CoordinatorEntity, SensorEntity):
                 # For count and moving_time, return as-is
                 return value
 
-        # Fallback for empty or string data
-        return 0
+        # Fallback for non-dict data (e.g. malformed API response)
+        return None
 
     @property
     def native_unit_of_measurement(self):

--- a/tests/custom_components/ha_strava/test_sensor.py
+++ b/tests/custom_components/ha_strava/test_sensor.py
@@ -555,6 +555,110 @@ class TestStravaSummaryStatsSensor:
 
         assert sensor.native_value is None
 
+    def test_sensor_state_missing_moving_time_field_is_unknown(self):
+        """Test sensor returns None when moving_time key is absent."""
+        summary_stats = {
+            "recent_run_totals": {
+                "distance": 5000.0,
+                "count": 5,
+                "elevation_gain": 100.0,
+                # "moving_time" intentionally omitted
+            }
+        }
+        coordinator = MagicMock()
+        coordinator.data = {
+            "summary_stats": summary_stats,
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+
+        sensor = StravaSummaryStatsSensor(
+            coordinator=coordinator,
+            api_key="recent_run_totals",
+            display_name="Recent Run Moving Time",
+            metric_key="moving_time",
+            athlete_id="12345",
+        )
+
+        assert sensor.native_value is None
+
+    def test_sensor_state_zero_moving_time_field_is_zero(self):
+        """Test sensor still returns 0 when moving_time key is present and explicitly zero."""
+        summary_stats = {
+            "recent_run_totals": {
+                "distance": 0.0,
+                "moving_time": 0,
+                "count": 0,
+                "elevation_gain": 0.0,
+            }
+        }
+        coordinator = MagicMock()
+        coordinator.data = {
+            "summary_stats": summary_stats,
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+
+        sensor = StravaSummaryStatsSensor(
+            coordinator=coordinator,
+            api_key="recent_run_totals",
+            display_name="Recent Run Moving Time",
+            metric_key="moving_time",
+            athlete_id="12345",
+        )
+
+        assert sensor.native_value == 0
+
+    def test_sensor_state_missing_biggest_climb_elevation_gain_is_unknown(self):
+        """Test the biggest_climb_elevation_gain special-case sensor returns None when absent."""
+        summary_stats = {
+            "recent_ride_totals": {"elevation_gain": 500.0},
+            # "biggest_climb_elevation_gain" intentionally omitted from summary_stats
+        }
+        coordinator = MagicMock()
+        coordinator.data = {
+            "summary_stats": summary_stats,
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+        coordinator.entry = MagicMock()
+        coordinator.entry.options = {
+            CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_METRIC
+        }
+
+        sensor = StravaSummaryStatsSensor(
+            coordinator=coordinator,
+            api_key="biggest_climb_elevation_gain",
+            display_name="Longest Climb Elevation Gain",
+            metric_key="biggest_climb_elevation_gain",
+            athlete_id="12345",
+        )
+
+        assert sensor.native_value is None
+
+    def test_sensor_state_malformed_biggest_ride_distance_is_unknown(self):
+        """Test the biggest_ride_distance sensor returns None for a non-numeric value
+        instead of silently coercing it to 0."""
+        summary_stats = {
+            "biggest_ride_distance": "not-a-number",
+        }
+        coordinator = MagicMock()
+        coordinator.data = {
+            "summary_stats": summary_stats,
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+        coordinator.entry = MagicMock()
+        coordinator.entry.options = {
+            CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_METRIC
+        }
+
+        sensor = StravaSummaryStatsSensor(
+            coordinator=coordinator,
+            api_key="biggest_ride_distance",
+            display_name="Longest Ride Distance",
+            metric_key="biggest_ride_distance",
+            athlete_id="12345",
+        )
+
+        assert sensor.native_value is None
+
     def test_sensor_attributes(self, mock_strava_stats):
         """Test sensor attributes."""
         # Create proper summary_stats structure with raw API data

--- a/tests/custom_components/ha_strava/test_sensor.py
+++ b/tests/custom_components/ha_strava/test_sensor.py
@@ -387,6 +387,174 @@ class TestStravaSummaryStatsSensor:
         state = sensor.native_value
         assert state is None
 
+    def test_sensor_state_missing_distance_field_is_unknown(self):
+        """Test sensor returns None when distance key is absent from an otherwise-present bucket."""
+        summary_stats = {
+            "recent_run_totals": {
+                "moving_time": 1800,
+                "count": 5,
+                "elevation_gain": 100.0,
+                # "distance" intentionally omitted
+            }
+        }
+        coordinator = MagicMock()
+        coordinator.data = {
+            "summary_stats": summary_stats,
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+        coordinator.entry = MagicMock()
+        coordinator.entry.options = {
+            CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_METRIC
+        }
+
+        sensor = StravaSummaryStatsSensor(
+            coordinator=coordinator,
+            api_key="recent_run_totals",
+            display_name="Recent Run Distance",
+            metric_key="distance",
+            athlete_id="12345",
+        )
+
+        assert sensor.native_value is None
+
+    def test_sensor_state_zero_distance_field_is_zero(self):
+        """Test sensor still returns 0.0 when distance key is present and explicitly zero."""
+        summary_stats = {
+            "recent_run_totals": {
+                "distance": 0.0,
+                "moving_time": 0,
+                "count": 0,
+                "elevation_gain": 0.0,
+            }
+        }
+        coordinator = MagicMock()
+        coordinator.data = {
+            "summary_stats": summary_stats,
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+        coordinator.entry = MagicMock()
+        coordinator.entry.options = {
+            CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_METRIC
+        }
+
+        sensor = StravaSummaryStatsSensor(
+            coordinator=coordinator,
+            api_key="recent_run_totals",
+            display_name="Recent Run Distance",
+            metric_key="distance",
+            athlete_id="12345",
+        )
+
+        assert sensor.native_value == 0.0
+
+    def test_sensor_state_missing_elevation_gain_field_is_unknown(self):
+        """Test sensor returns None when elevation_gain key is absent."""
+        summary_stats = {
+            "recent_ride_totals": {
+                "distance": 25000.0,
+                "moving_time": 3600,
+                "count": 3,
+                # "elevation_gain" intentionally omitted
+            }
+        }
+        coordinator = MagicMock()
+        coordinator.data = {
+            "summary_stats": summary_stats,
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+        coordinator.entry = MagicMock()
+        coordinator.entry.options = {
+            CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_METRIC
+        }
+
+        sensor = StravaSummaryStatsSensor(
+            coordinator=coordinator,
+            api_key="recent_ride_totals",
+            display_name="Recent Ride Elevation Gain",
+            metric_key="elevation_gain",
+            athlete_id="12345",
+        )
+
+        assert sensor.native_value is None
+
+    def test_sensor_state_missing_count_field_is_unknown(self):
+        """Test sensor returns None when count key is absent (plain passthrough metric)."""
+        summary_stats = {
+            "recent_swim_totals": {
+                "distance": 500.0,
+                "moving_time": 900,
+                "elevation_gain": 0.0,
+                # "count" intentionally omitted
+            }
+        }
+        coordinator = MagicMock()
+        coordinator.data = {
+            "summary_stats": summary_stats,
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+
+        sensor = StravaSummaryStatsSensor(
+            coordinator=coordinator,
+            api_key="recent_swim_totals",
+            display_name="Recent Swim Count",
+            metric_key="count",
+            athlete_id="12345",
+        )
+
+        assert sensor.native_value is None
+
+    def test_sensor_state_zero_count_field_is_zero(self):
+        """Test sensor still returns 0 when count key is present and explicitly zero."""
+        summary_stats = {
+            "recent_swim_totals": {
+                "distance": 0.0,
+                "moving_time": 0,
+                "count": 0,
+                "elevation_gain": 0.0,
+            }
+        }
+        coordinator = MagicMock()
+        coordinator.data = {
+            "summary_stats": summary_stats,
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+
+        sensor = StravaSummaryStatsSensor(
+            coordinator=coordinator,
+            api_key="recent_swim_totals",
+            display_name="Recent Swim Count",
+            metric_key="count",
+            athlete_id="12345",
+        )
+
+        assert sensor.native_value == 0
+
+    def test_sensor_state_missing_biggest_ride_distance_is_unknown(self):
+        """Test the biggest_ride_distance special-case sensor returns None when the field is absent."""
+        summary_stats = {
+            "recent_run_totals": {"distance": 5000.0},
+            # "biggest_ride_distance" intentionally omitted from summary_stats
+        }
+        coordinator = MagicMock()
+        coordinator.data = {
+            "summary_stats": summary_stats,
+            "athlete": {"id": 12345, "firstname": "Test", "lastname": "User"},
+        }
+        coordinator.entry = MagicMock()
+        coordinator.entry.options = {
+            CONF_DISTANCE_UNIT_OVERRIDE: CONF_DISTANCE_UNIT_OVERRIDE_METRIC
+        }
+
+        sensor = StravaSummaryStatsSensor(
+            coordinator=coordinator,
+            api_key="biggest_ride_distance",
+            display_name="Longest Ride Distance",
+            metric_key="biggest_ride_distance",
+            athlete_id="12345",
+        )
+
+        assert sensor.native_value is None
+
     def test_sensor_attributes(self, mock_strava_stats):
         """Test sensor attributes."""
         # Create proper summary_stats structure with raw API data


### PR DESCRIPTION
## Summary
- `StravaSummaryStatsSensor` now returns `None` (`unknown` in Home Assistant) when a metric field is absent from an otherwise-present totals bucket, instead of silently defaulting to `0`
- A field explicitly present with value `0` is unaffected and still reports `0`
- A non-numeric/malformed value in the "biggest ride/climb" special-case sensors now also returns `None` instead of silently coercing to `0`
- Applies to recent/YTD/all-time/weekly Run/Ride/Swim sensors and the two "biggest ride/climb" sensors

Addresses feedback from #337 (https://github.com/craibo/ha_strava/pull/337#issuecomment-5327798324) — sensors were showing `0` instead of surfacing genuinely missing/malformed data.

Note for a future follow-up: the per-activity `StravaActivityMetricSensor`/`StravaRecentActivityMetricSensor` classes have the same underlying issue (`value / 1000 if value else 0` coerces `_get_value_or_unavailable`'s deliberate `None` back to `0`) — out of scope here since this PR only touches the summary-stats sensor, but worth a follow-up.